### PR TITLE
Add unbreakable glow and admin bin for special items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+SpecialItems/.gradle/
+SpecialItems/build/

--- a/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
+++ b/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
@@ -1,11 +1,13 @@
 package com.specialitems;
 
 import com.specialitems.commands.SiCommand;
+import com.specialitems.commands.BinCommand;
 import com.specialitems.effects.Effects;
 import com.specialitems.listeners.BlockListener;
 import com.specialitems.listeners.CombatListener;
 import com.specialitems.listeners.PlayerListener;
 import com.specialitems.listeners.GuiListener;
+import com.specialitems.listeners.BinListener;
 import com.specialitems.util.Configs;
 import com.specialitems.util.Log;
 import org.bukkit.Bukkit;
@@ -48,6 +50,7 @@ public class SpecialItemsPlugin extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new CombatListener(), this);
             getServer().getPluginManager().registerEvents(new GuiListener(), this);
             getServer().getPluginManager().registerEvents(new PlayerListener(), this);
+            getServer().getPluginManager().registerEvents(new BinListener(this), this);
         } catch (Throwable t) {
             Log.warn("Listener registration failed: " + t.getMessage());
         }
@@ -61,6 +64,15 @@ public class SpecialItemsPlugin extends JavaPlugin {
             }
         } else {
             Log.warn("Command 'si' not found in plugin.yml!");
+        }
+        if (getCommand("bin") != null) {
+            try {
+                getCommand("bin").setExecutor(new BinCommand());
+            } catch (Throwable t) {
+                Log.warn("Failed to set executor for /bin: " + t.getMessage());
+            }
+        } else {
+            Log.warn("Command 'bin' not found in plugin.yml!");
         }
 
         // --- Leveling system (NEW) ---

--- a/SpecialItems/src/main/java/com/specialitems/bin/Bin.java
+++ b/SpecialItems/src/main/java/com/specialitems/bin/Bin.java
@@ -1,0 +1,26 @@
+package com.specialitems.bin;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class Bin {
+    private static final List<ItemStack> ITEMS = new ArrayList<>();
+
+    private Bin() {}
+
+    public static void store(ItemStack it) {
+        if (it == null || it.getType().isAir()) return;
+        ITEMS.add(it.clone());
+    }
+
+    public static List<ItemStack> getItems() {
+        return Collections.unmodifiableList(ITEMS);
+    }
+
+    public static ItemStack take(int index) {
+        return (index >= 0 && index < ITEMS.size()) ? ITEMS.remove(index) : null;
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/commands/BinCommand.java
+++ b/SpecialItems/src/main/java/com/specialitems/commands/BinCommand.java
@@ -1,0 +1,24 @@
+package com.specialitems.commands;
+
+import com.specialitems.gui.BinGUI;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class BinCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        if (!(sender instanceof Player p)) {
+            sender.sendMessage(ChatColor.RED + "Players only.");
+            return true;
+        }
+        if (!p.hasPermission("specialitems.admin")) {
+            p.sendMessage(ChatColor.RED + "No permission.");
+            return true;
+        }
+        BinGUI.open(p);
+        return true;
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/commands/SiCommand.java
+++ b/SpecialItems/src/main/java/com/specialitems/commands/SiCommand.java
@@ -19,7 +19,11 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public class SiCommand implements CommandExecutor {
 
@@ -35,6 +39,22 @@ public class SiCommand implements CommandExecutor {
         sender.sendMessage(ChatColor.YELLOW + "/si retag " + ChatColor.WHITE + "[id]" + ChatColor.GRAY + " — Tag held item as Special (admin)");
     }
 
+    private static boolean requirePlayer(CommandSender sender) {
+        if (sender instanceof Player) {
+            return true;
+        }
+        sender.sendMessage(ChatColor.RED + "Players only.");
+        return false;
+    }
+
+    private static boolean requireAdmin(CommandSender sender) {
+        if (sender.hasPermission("specialitems.admin")) {
+            return true;
+        }
+        sender.sendMessage(ChatColor.RED + "No permission.");
+        return false;
+    }
+
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (args.length == 0) {
@@ -43,137 +63,147 @@ public class SiCommand implements CommandExecutor {
         }
 
         String sub = args[0].toLowerCase(Locale.ROOT);
-
-        if (sub.equals("gui")) {
-            if (!(sender instanceof Player)) { sender.sendMessage(ChatColor.RED + "Players only."); return true; }
-            if (!sender.hasPermission("specialitems.admin")) { sender.sendMessage(ChatColor.RED + "No permission."); return true; }
-            TemplateGUI.open((Player) sender, 0);
-            return true;
-        }
-
-        if (sub.equals("give")) {
-            if (!sender.hasPermission("specialitems.admin")) { sender.sendMessage(ChatColor.RED + "No permission."); return true; }
-            if (args.length < 3) { sender.sendMessage(ChatColor.RED + "Usage: /si give <player> <templateId>"); return true; }
-            Player target = Bukkit.getPlayerExact(args[1]);
-            if (target == null) { sender.sendMessage(ChatColor.RED + "Player not found: " + args[1]); return true; }
-            String tid = args[2];
-            ConfigurationSection tsec = Configs.templates.getConfigurationSection("templates." + tid);
-            if (tsec == null) { sender.sendMessage(ChatColor.RED + "Template not found: " + tid); return true; }
-            ItemStack item = TemplateItems.buildFrom(tid, tsec);
-            target.getInventory().addItem(item);
-            sender.sendMessage(ChatColor.GREEN + "Gave " + ChatColor.YELLOW + tid + ChatColor.GREEN + " to " + ChatColor.YELLOW + target.getName());
-            return true;
-        }
-
-        if (sub.equals("reload")) {
-            if (!sender.hasPermission("specialitems.admin")) { sender.sendMessage(ChatColor.RED + "No permission."); return true; }
-            Configs.load(SpecialItemsPlugin.getInstance());
-            sender.sendMessage(ChatColor.GREEN + "SpecialItems configuration reloaded.");
-            return true;
-        }
-
-        if (sub.equals("retag")) {
-            if (!sender.hasPermission("specialitems.admin")) { sender.sendMessage(ChatColor.RED + "No permission."); return true; }
-            if (!(sender instanceof Player)) { sender.sendMessage(ChatColor.RED + "Players only."); return true; }
-            Player p = (Player) sender;
-            ItemStack held = p.getInventory().getItemInMainHand();
-            if (held == null || held.getType().isAir()) { p.sendMessage(ChatColor.RED + "Hold the item you want to tag."); return true; }
-            String id = (args.length >= 2) ? args[1] : (held.hasItemMeta() && held.getItemMeta().hasDisplayName() ? held.getItemMeta().getDisplayName() : held.getType().name());
-            id = id.replaceAll("§.", "").replaceAll("[^A-Za-z0-9]+", "_").toLowerCase(Locale.ROOT);
-            Tagger.tagAsSpecial(SpecialItemsPlugin.getInstance(), held, id);
-            p.sendMessage(ChatColor.GREEN + "Item tagged as Special: " + ChatColor.YELLOW + id);
-            return true;
-        }
-
-        if (sub.equals("levels") || sub.equals("level")) {
-            if (!(sender instanceof Player)) { sender.sendMessage(ChatColor.RED + "Players only."); return true; }
-            LevelOverviewGUI.open((Player) sender);
-            return true;
-        }
-
-        if (sub.equals("inspect")) {
-            if (!(sender instanceof Player)) { sender.sendMessage(ChatColor.RED + "Players only."); return true; }
-            Player p = (Player) sender;
-            SpecialItemsPlugin pl = SpecialItemsPlugin.getInstance();
-            ItemStack held = p.getInventory().getItemInMainHand();
-            if (!pl.leveling().isSpecialItem(held) && ItemUtil.getEffectLevel(held, "veinminer") <= 0 && ItemUtil.getEffectLevel(held, "telekinesis") <= 0) {
-                p.sendMessage(ChatColor.RED + "Hold a Special Item."); return true;
-            }
-            int lvl = pl.leveling().getLevel(held);
-            double xp = pl.leveling().getXp(held);
-            double need = LevelMath.neededXpFor(lvl);
-            ToolClass tc = pl.leveling().detectToolClass(held);
-            p.sendMessage(ChatColor.GOLD + "Tool: " + ChatColor.YELLOW + tc);
-            p.sendMessage(ChatColor.GOLD + "Level: " + ChatColor.YELLOW + lvl +
-                    ChatColor.GRAY + " (" + String.format("%.1f", xp) + " / " + String.format("%.1f", need) + ")");
-            if (tc == ToolClass.HOE) {
-                double by = pl.leveling().getBonusYieldPct(held);
-                p.sendMessage(ChatColor.GOLD + "Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
-            }
-            return true;
-        }
-
-        if (sub.equals("publicinspect") || sub.equals("pi")) {
-            if (!(sender instanceof Player)) { sender.sendMessage(ChatColor.RED + "Players only."); return true; }
-            Player p = (Player) sender;
-            SpecialItemsPlugin pl = SpecialItemsPlugin.getInstance();
-            ItemStack held = p.getInventory().getItemInMainHand();
-            if (!pl.leveling().isSpecialItem(held) && ItemUtil.getEffectLevel(held, "veinminer") <= 0 && ItemUtil.getEffectLevel(held, "telekinesis") <= 0) {
-                p.sendMessage(ChatColor.RED + "Hold a Special Item."); return true;
-            }
-            int lvl = pl.leveling().getLevel(held);
-            double xp = pl.leveling().getXp(held);
-            double need = LevelMath.neededXpFor(lvl);
-            ToolClass tc = pl.leveling().detectToolClass(held);
-            Bukkit.broadcastMessage(ChatColor.DARK_AQUA + "[PublicInspect] " +
-                    ChatColor.AQUA + p.getName() + ChatColor.GRAY + " shows a Special Item:");
-            Bukkit.broadcastMessage(ChatColor.GOLD + "✦ Tool: " + ChatColor.YELLOW + tc);
-            Bukkit.broadcastMessage(ChatColor.GOLD + "✦ Level: " + ChatColor.YELLOW + lvl +
-                    ChatColor.GRAY + " (" + String.format("%.1f", xp) + " / " + String.format("%.1f", need) + ")");
-            if (tc == ToolClass.HOE) {
-                double by = pl.leveling().getBonusYieldPct(held);
-                Bukkit.broadcastMessage(ChatColor.GOLD + "✦ Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
-            }
-            return true;
-        }
-
-        if (sub.equals("list")) {
-            if (args.length < 2) {
-                sender.sendMessage(ChatColor.RED + "Usage: /si list <effects|templates>");
+        switch (sub) {
+            case "gui" -> {
+                if (!requirePlayer(sender) || !requireAdmin(sender)) return true;
+                TemplateGUI.open((Player) sender, 0);
                 return true;
             }
-            String kind = args[1].toLowerCase(Locale.ROOT);
-            if (kind.equals("effects")) {
-                java.util.List<String> ids = new java.util.ArrayList<>(Effects.ids());
-                if (ids.isEmpty()) {
-                    java.util.Set<String> fallback = new java.util.LinkedHashSet<>();
-                    var troot = Configs.templates.getConfigurationSection("templates");
-                    if (troot != null) {
-                        for (String id : troot.getKeys(false)) {
-                            var t = troot.getConfigurationSection(id);
-                            if (t != null) {
-                                var ench = t.getConfigurationSection("enchants");
-                                if (ench != null) fallback.addAll(ench.getKeys(false));
+            case "give" -> {
+                if (!requireAdmin(sender)) return true;
+                if (args.length < 3) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /si give <player> <templateId>");
+                    return true;
+                }
+                Player target = Bukkit.getPlayerExact(args[1]);
+                if (target == null) {
+                    sender.sendMessage(ChatColor.RED + "Player not found: " + args[1]);
+                    return true;
+                }
+                String tid = args[2];
+                ConfigurationSection tsec = Configs.templates.getConfigurationSection("templates." + tid);
+                if (tsec == null) {
+                    sender.sendMessage(ChatColor.RED + "Template not found: " + tid);
+                    return true;
+                }
+                ItemStack item = TemplateItems.buildFrom(tid, tsec);
+                target.getInventory().addItem(item);
+                sender.sendMessage(ChatColor.GREEN + "Gave " + ChatColor.YELLOW + tid + ChatColor.GREEN + " to " + ChatColor.YELLOW + target.getName());
+                return true;
+            }
+            case "reload" -> {
+                if (!requireAdmin(sender)) return true;
+                Configs.load(SpecialItemsPlugin.getInstance());
+                sender.sendMessage(ChatColor.GREEN + "SpecialItems configuration reloaded.");
+                return true;
+            }
+            case "retag" -> {
+                if (!requirePlayer(sender) || !requireAdmin(sender)) return true;
+                Player p = (Player) sender;
+                ItemStack held = p.getInventory().getItemInMainHand();
+                if (held == null || held.getType().isAir()) {
+                    p.sendMessage(ChatColor.RED + "Hold the item you want to tag.");
+                    return true;
+                }
+                String id = (args.length >= 2) ? args[1] : (held.hasItemMeta() && held.getItemMeta().hasDisplayName() ? held.getItemMeta().getDisplayName() : held.getType().name());
+                id = id.replaceAll("§.", "").replaceAll("[^A-Za-z0-9]+", "_").toLowerCase(Locale.ROOT);
+                Tagger.tagAsSpecial(SpecialItemsPlugin.getInstance(), held, id);
+                p.sendMessage(ChatColor.GREEN + "Item tagged as Special: " + ChatColor.YELLOW + id);
+                return true;
+            }
+            case "levels", "level" -> {
+                if (!requirePlayer(sender)) return true;
+                LevelOverviewGUI.open((Player) sender);
+                return true;
+            }
+            case "inspect" -> {
+                if (!requirePlayer(sender)) return true;
+                Player p = (Player) sender;
+                SpecialItemsPlugin pl = SpecialItemsPlugin.getInstance();
+                ItemStack held = p.getInventory().getItemInMainHand();
+                if (!pl.leveling().isSpecialItem(held) && ItemUtil.getEffectLevel(held, "veinminer") <= 0 && ItemUtil.getEffectLevel(held, "telekinesis") <= 0) {
+                    p.sendMessage(ChatColor.RED + "Hold a Special Item.");
+                    return true;
+                }
+                int lvl = pl.leveling().getLevel(held);
+                double xp = pl.leveling().getXp(held);
+                double need = LevelMath.neededXpFor(lvl);
+                ToolClass tc = pl.leveling().detectToolClass(held);
+                p.sendMessage(ChatColor.GOLD + "Tool: " + ChatColor.YELLOW + tc);
+                p.sendMessage(ChatColor.GOLD + "Level: " + ChatColor.YELLOW + lvl +
+                        ChatColor.GRAY + " (" + String.format("%.1f", xp) + " / " + String.format("%.1f", need) + ")");
+                if (tc == ToolClass.HOE) {
+                    double by = pl.leveling().getBonusYieldPct(held);
+                    p.sendMessage(ChatColor.GOLD + "Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
+                }
+                return true;
+            }
+            case "publicinspect", "pi" -> {
+                if (!requirePlayer(sender)) return true;
+                Player p = (Player) sender;
+                SpecialItemsPlugin pl = SpecialItemsPlugin.getInstance();
+                ItemStack held = p.getInventory().getItemInMainHand();
+                if (!pl.leveling().isSpecialItem(held) && ItemUtil.getEffectLevel(held, "veinminer") <= 0 && ItemUtil.getEffectLevel(held, "telekinesis") <= 0) {
+                    p.sendMessage(ChatColor.RED + "Hold a Special Item.");
+                    return true;
+                }
+                int lvl = pl.leveling().getLevel(held);
+                double xp = pl.leveling().getXp(held);
+                double need = LevelMath.neededXpFor(lvl);
+                ToolClass tc = pl.leveling().detectToolClass(held);
+                Bukkit.broadcastMessage(ChatColor.DARK_AQUA + "[PublicInspect] " +
+                        ChatColor.AQUA + p.getName() + ChatColor.GRAY + " shows a Special Item:");
+                Bukkit.broadcastMessage(ChatColor.GOLD + "✦ Tool: " + ChatColor.YELLOW + tc);
+                Bukkit.broadcastMessage(ChatColor.GOLD + "✦ Level: " + ChatColor.YELLOW + lvl +
+                        ChatColor.GRAY + " (" + String.format("%.1f", xp) + " / " + String.format("%.1f", need) + ")");
+                if (tc == ToolClass.HOE) {
+                    double by = pl.leveling().getBonusYieldPct(held);
+                    Bukkit.broadcastMessage(ChatColor.GOLD + "✦ Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
+                }
+                return true;
+            }
+            case "list" -> {
+                if (args.length < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /si list <effects|templates>");
+                    return true;
+                }
+                String kind = args[1].toLowerCase(Locale.ROOT);
+                if (kind.equals("effects")) {
+                    List<String> ids = new ArrayList<>(Effects.ids());
+                    if (ids.isEmpty()) {
+                        Set<String> fallback = new LinkedHashSet<>();
+                        var troot = Configs.templates.getConfigurationSection("templates");
+                        if (troot != null) {
+                            for (String id : troot.getKeys(false)) {
+                                var t = troot.getConfigurationSection(id);
+                                if (t != null) {
+                                    var ench = t.getConfigurationSection("enchants");
+                                    if (ench != null) fallback.addAll(ench.getKeys(false));
+                                }
                             }
                         }
+                        ids.addAll(fallback);
                     }
-                    ids.addAll(fallback);
+                    sender.sendMessage(ChatColor.GOLD + "Registered effects: " + (ids.isEmpty() ? (ChatColor.RED + "(none)") : (ChatColor.YELLOW + String.join(ChatColor.GRAY + ", " + ChatColor.YELLOW, ids))));
+                    return true;
+                } else if (kind.equals("templates")) {
+                    ConfigurationSection troot = Configs.templates.getConfigurationSection("templates");
+                    if (troot == null) {
+                        sender.sendMessage(ChatColor.RED + "No templates found.");
+                        return true;
+                    }
+                    Set<String> keys = troot.getKeys(false);
+                    sender.sendMessage(ChatColor.GOLD + "Templates: " + (keys.isEmpty() ? (ChatColor.RED + "(none)") : (ChatColor.YELLOW + String.join(ChatColor.GRAY + ", " + ChatColor.YELLOW, keys))));
+                    return true;
+                } else {
+                    sender.sendMessage(ChatColor.RED + "Usage: /si list <effects|templates>");
+                    return true;
                 }
-                sender.sendMessage(ChatColor.GOLD + "Registered effects: " + (ids.isEmpty() ? (ChatColor.RED + "(none)") : (ChatColor.YELLOW + String.join(ChatColor.GRAY + ", " + ChatColor.YELLOW, ids))));
-                return true;
-            } else if (kind.equals("templates")) {
-                ConfigurationSection troot = Configs.templates.getConfigurationSection("templates");
-                if (troot == null) { sender.sendMessage(ChatColor.RED + "No templates found."); return true; }
-                java.util.Set<String> keys = troot.getKeys(false);
-                sender.sendMessage(ChatColor.GOLD + "Templates: " + (keys.isEmpty() ? (ChatColor.RED + "(none)") : (ChatColor.YELLOW + String.join(ChatColor.GRAY + ", " + ChatColor.YELLOW, keys))));
-                return true;
-            } else {
-                sender.sendMessage(ChatColor.RED + "Usage: /si list <effects|templates>");
+            }
+            default -> {
+                sendHelp(sender);
                 return true;
             }
         }
-
-        sendHelp(sender);
-        return true;
     }
 }

--- a/SpecialItems/src/main/java/com/specialitems/gui/BinGUI.java
+++ b/SpecialItems/src/main/java/com/specialitems/gui/BinGUI.java
@@ -1,0 +1,34 @@
+package com.specialitems.gui;
+
+import com.specialitems.bin.Bin;
+import com.specialitems.util.Configs;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+public final class BinGUI {
+    public static final String TITLE = ChatColor.DARK_RED + "Special Item Bin";
+    private static final int SIZE = 6 * 9;
+
+    private BinGUI() {}
+
+    public static void open(Player p) {
+        if (!p.hasPermission("specialitems.admin")) {
+            p.sendMessage(ChatColor.translateAlternateColorCodes('&', Configs.msg.getString("no-permission","&cNo permission.")));
+            return;
+        }
+        Inventory inv = Bukkit.createInventory(p, SIZE, TITLE);
+        List<ItemStack> items = Bin.getItems();
+        int i = 0;
+        for (ItemStack it : items) {
+            if (i >= SIZE - 1) break;
+            inv.setItem(i++, it.clone());
+        }
+        inv.setItem(SIZE - 1, GuiIcons.navClose());
+        p.openInventory(inv);
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelOverviewGUI.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelOverviewGUI.java
@@ -162,11 +162,6 @@ public final class LevelOverviewGUI implements InventoryHolder, Listener {
         inv.clear();
         PlayerInventory pinv = target.getInventory();
         for (ItemStack it : pinv.getContents()) addIfSpecial(it);
-        addIfSpecial(pinv.getItemInOffHand());
-        addIfSpecial(pinv.getHelmet());
-        addIfSpecial(pinv.getChestplate());
-        addIfSpecial(pinv.getLeggings());
-        addIfSpecial(pinv.getBoots());
     }
 
     @EventHandler

--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelingListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelingListener.java
@@ -1,5 +1,6 @@
 package com.specialitems.leveling;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
@@ -42,11 +43,15 @@ public final class LevelingListener implements Listener {
                         default -> 0.0;
                     };
                 }
-                if (add > 0) svc.grantXp(held, add, clazz);
+                if (add > 0) {
+                    var ups = svc.grantXp(held, add, clazz);
+                    sendMsgs(p, held, ups);
+                }
             }
             case HOE -> {
                 if (HarvestUtil.isCrop(m) && HarvestUtil.isMatureCrop(b)) {
-                    svc.grantXp(held, svc.xpHoeHarvest, clazz);
+                    var ups = svc.grantXp(held, svc.xpHoeHarvest, clazz);
+                    sendMsgs(p, held, ups);
                 }
             }
             default -> {}
@@ -66,7 +71,17 @@ public final class LevelingListener implements Listener {
         if (clazz != ToolClass.SWORD) return;
 
         double add = isBoss(dead.getType()) ? svc.xpSwordBossKill : svc.xpSwordKill;
-        svc.grantXp(held, add, clazz);
+        var ups = svc.grantXp(held, add, clazz);
+        sendMsgs(killer, held, ups);
+    }
+
+    private void sendMsgs(Player p, ItemStack item, java.util.List<LevelingService.LevelUp> ups) {
+        if (ups == null || ups.isEmpty()) return;
+        String name = (item.hasItemMeta() && item.getItemMeta().hasDisplayName()) ? item.getItemMeta().getDisplayName() : item.getType().name();
+        for (var up : ups) {
+            p.sendMessage(ChatColor.AQUA + name + ChatColor.GREEN + " reached level " + ChatColor.YELLOW + up.level() +
+                    (up.enchanted() ? ChatColor.GREEN + " and gained a bonus enchantment!" : ChatColor.GRAY + " without a bonus enchantment."));
+        }
     }
 
     private boolean isBoss(EntityType t) {

--- a/SpecialItems/src/main/java/com/specialitems/listeners/BinListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/BinListener.java
@@ -1,0 +1,35 @@
+package com.specialitems.listeners;
+
+import com.specialitems.SpecialItemsPlugin;
+import com.specialitems.bin.Bin;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ItemDespawnEvent;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+public final class BinListener implements Listener {
+    private final SpecialItemsPlugin plugin;
+
+    public BinListener(SpecialItemsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBreak(PlayerItemBreakEvent e) {
+        ItemStack it = e.getBrokenItem();
+        if (plugin.leveling().isSpecialItem(it)) {
+            Bin.store(it);
+            e.getPlayer().sendMessage(ChatColor.YELLOW + "Your special item was moved to the bin.");
+        }
+    }
+
+    @EventHandler
+    public void onDespawn(ItemDespawnEvent e) {
+        ItemStack it = e.getEntity().getItemStack();
+        if (plugin.leveling().isSpecialItem(it)) {
+            Bin.store(it);
+        }
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/listeners/GuiListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/GuiListener.java
@@ -1,7 +1,8 @@
 package com.specialitems.listeners;
 
+import com.specialitems.bin.Bin;
+import com.specialitems.gui.BinGUI;
 import com.specialitems.gui.TemplateGUI;
-import com.specialitems.util.TemplateItems;
 import com.specialitems.util.Configs;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -18,7 +19,31 @@ public class GuiListener implements Listener {
     public void onClick(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
         String title = e.getView().getTitle();
-        if (title == null || !title.startsWith(ChatColor.AQUA + "SpecialItems Templates")) return;
+        if (title == null) return;
+
+        if (title.equals(BinGUI.TITLE)) {
+            e.setCancelled(true);
+            if (!p.hasPermission("specialitems.admin")) {
+                p.closeInventory();
+                p.sendMessage(ChatColor.translateAlternateColorCodes('&', Configs.msg.getString("no-permission","&cNo permission.")));
+                return;
+            }
+            int raw = e.getRawSlot();
+            if (raw < 0) return;
+            if (raw == e.getInventory().getSize() - 1) {
+                p.closeInventory();
+                return;
+            }
+            ItemStack removed = Bin.take(raw);
+            if (removed != null) {
+                p.getInventory().addItem(removed);
+                p.sendMessage(ChatColor.GREEN + "Recovered item.");
+                BinGUI.open(p);
+            }
+            return;
+        }
+
+        if (!title.startsWith(ChatColor.AQUA + "SpecialItems Templates")) return;
         e.setCancelled(true);
         if (!p.hasPermission("specialitems.admin")) {
             p.closeInventory();

--- a/SpecialItems/src/main/java/com/specialitems/util/Tagger.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/Tagger.java
@@ -1,6 +1,8 @@
 package com.specialitems.util;
 
 import com.specialitems.leveling.Keys;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
@@ -22,7 +24,14 @@ public final class Tagger {
         var keys = new Keys(plugin);
         if (!pdc.has(keys.SI_ID, PersistentDataType.STRING)) {
             pdc.set(keys.SI_ID, PersistentDataType.STRING, templateId == null ? "unknown" : templateId);
-            item.setItemMeta(meta);
         }
+
+        meta.setUnbreakable(true);
+        try { meta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE, ItemFlag.HIDE_ENCHANTS); } catch (Throwable ignored) {}
+        if (meta.getEnchants().isEmpty()) {
+            try { meta.addEnchant(Enchantment.UNBREAKING, 1, true); } catch (Throwable ignored) {}
+        }
+
+        item.setItemMeta(meta);
     }
 }

--- a/SpecialItems/src/main/resources/plugin.yml
+++ b/SpecialItems/src/main/resources/plugin.yml
@@ -7,6 +7,10 @@ commands:
   si:
     description: SpecialItems command
     usage: /si
+  bin:
+    description: View deleted special items (admin)
+    usage: /bin
+    permission: specialitems.admin
 permissions:
   specialitems.admin:
     description: Allows using admin SpecialItems subcommands


### PR DESCRIPTION
## Summary
- Make all tagged items unbreakable, hidden, and glowing
- Send level-up messages and correct duplicate armor in level overview
- Introduce recoverable bin with /bin admin command and listeners

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a1e215cb9c8325b39db83449b9df40