### PR TITLE
Cleanup special item appearance and lore

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/gui/BinGUI.java
+++ b/SpecialItems/src/main/java/com/specialitems/gui/BinGUI.java
@@ -2,6 +2,8 @@ package com.specialitems.gui;
 
 import com.specialitems.bin.Bin;
 import com.specialitems.util.Configs;
+import com.specialitems.util.GuiItemUtil;
+import com.specialitems.SpecialItemsPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -26,7 +28,9 @@ public final class BinGUI {
         int i = 0;
         for (ItemStack it : items) {
             if (i >= SIZE - 1) break;
-            inv.setItem(i++, it.clone());
+            ItemStack display = GuiItemUtil.forDisplay(SpecialItemsPlugin.getInstance(), it);
+            if (display == null) display = it.clone();
+            inv.setItem(i++, display);
         }
         inv.setItem(SIZE - 1, GuiIcons.navClose());
         p.openInventory(inv);

--- a/SpecialItems/src/main/java/com/specialitems/gui/TemplateGUI.java
+++ b/SpecialItems/src/main/java/com/specialitems/gui/TemplateGUI.java
@@ -2,6 +2,8 @@ package com.specialitems.gui;
 
 import com.specialitems.util.TemplateItems;
 import com.specialitems.util.Configs;
+import com.specialitems.util.GuiItemUtil;
+import com.specialitems.SpecialItemsPlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -30,7 +32,9 @@ public final class TemplateGUI {
         int end = Math.min(all.size(), start + PAGE_SIZE);
         int slot = 0;
         for (int i = start; i < end; i++) {
-            inv.setItem(slot++, all.get(i).stack().clone());
+            ItemStack display = GuiItemUtil.forDisplay(SpecialItemsPlugin.getInstance(), all.get(i).stack());
+            if (display == null) display = all.get(i).stack().clone();
+            inv.setItem(slot++, display);
         }
         // nav bar
         inv.setItem(45, GuiIcons.navPrev(page > 0));

--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelOverviewGUI.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelOverviewGUI.java
@@ -1,28 +1,18 @@
 package com.specialitems.leveling;
 
 import com.specialitems.SpecialItemsPlugin;
-import com.specialitems.effects.CustomEffect;
-import com.specialitems.effects.Effects;
-import com.specialitems.util.ItemUtil;
+import com.specialitems.util.GuiItemUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.persistence.PersistentDataContainer;
-import org.bukkit.persistence.PersistentDataType;
-
-import java.util.*;
 
 public final class LevelOverviewGUI implements InventoryHolder, Listener {
 
@@ -44,111 +34,9 @@ public final class LevelOverviewGUI implements InventoryHolder, Listener {
         p.openInventory(gui.inv);
     }
 
-    private static boolean hasSpecialPdc(ItemStack it) {
-        if (it == null) return false;
-        ItemMeta m = it.getItemMeta();
-        if (m == null) return false;
-        PersistentDataContainer pdc = m.getPersistentDataContainer();
-        if (pdc == null) return false;
-        for (NamespacedKey key : pdc.getKeys()) {
-            String k = key.getKey();
-            if (k != null && k.startsWith("ench_")) return true;
-        }
-        return false;
-    }
-
-    private static String roman(int n) {
-        String[] r = {"","I","II","III","IV","V","VI","VII","VIII","IX","X"};
-        if (n >= 0 && n < r.length) return r[n];
-        StringBuilder sb = new StringBuilder();
-        while (n >= 10) { sb.append("X"); n -= 10; }
-        if (n >= 9) { sb.append("IX"); n -= 9; }
-        if (n >= 5) { sb.append("V"); n -= 5; }
-        if (n >= 4) { sb.append("IV"); n -= 4; }
-        while (n >= 1) { sb.append("I"); n -= 1; }
-        return sb.toString();
-    }
-
-    private static String prettyVanilla(Enchantment e) {
-        String key = e.getKey().getKey().replace('_', ' ');
-        if (key.isEmpty()) return "Unknown";
-        return key.substring(0,1).toUpperCase(Locale.ROOT) + key.substring(1);
-    }
-
     private void addIfSpecial(ItemStack it) {
-        if (it == null || it.getType() == Material.AIR) return;
-        var svc = plugin.leveling();
-        boolean special = svc.isSpecialItem(it) || hasSpecialPdc(it);
-        if (!special) return;
-
-        int lvl = svc.getLevel(it);
-        double xp = svc.getXp(it);
-        double need = LevelMath.neededXpFor(lvl);
-
-        ItemStack display = it.clone();
-        ItemMeta meta = display.getItemMeta();
-        if (meta != null) {
-            try { meta.removeItemFlags(ItemFlag.values()); } catch (Throwable ignored) {}
-
-            List<String> lore = meta.hasLore() ? new ArrayList<>(meta.getLore()) : new ArrayList<>();
-            lore.add(ChatColor.GRAY + " ");
-            lore.add(ChatColor.GOLD + "Level: " + ChatColor.YELLOW + lvl);
-            lore.add(ChatColor.GOLD + "XP: " + ChatColor.YELLOW + String.format("%.1f", xp) + ChatColor.GRAY + " / " + ChatColor.YELLOW + String.format("%.1f", need));
-            if (plugin.leveling().detectToolClass(it) == ToolClass.HOE) {
-                double by = plugin.leveling().getBonusYieldPct(it);
-                lore.add(ChatColor.GOLD + "Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
-            }
-
-            Map<Enchantment, Integer> enchants = it.getEnchantments();
-            if (!enchants.isEmpty()) {
-                lore.add(ChatColor.GRAY + " ");
-                lore.add(ChatColor.BLUE + "" + ChatColor.BOLD + "Vanilla Enchants:");
-                for (Map.Entry<Enchantment, Integer> en : enchants.entrySet()) {
-                    lore.add(ChatColor.BLUE + " - " + prettyVanilla(en.getKey()) + " " + roman(en.getValue()));
-                }
-            }
-
-            List<String> specialLines = new ArrayList<>();
-            for (String id : Effects.ids()) {
-                int elv = 0;
-                try { elv = ItemUtil.getEffectLevel(it, id); } catch (Throwable ignored) {}
-                if (elv > 0) {
-                    CustomEffect ce = Effects.get(id);
-                    String name = (ce != null ? ce.displayName() : id);
-                    if (!name.isEmpty()) name = name.substring(0,1).toUpperCase(Locale.ROOT) + name.substring(1);
-                    specialLines.add(ChatColor.LIGHT_PURPLE + " - " + name + " " + roman(elv));
-                }
-            }
-
-            if (specialLines.isEmpty()) {
-                PersistentDataContainer pdc = meta.getPersistentDataContainer();
-                if (pdc != null) {
-                    for (NamespacedKey key : pdc.getKeys()) {
-                        String k = key.getKey();
-                        if (k != null && k.startsWith("ench_")) {
-                            String effectId = k.substring("ench_".length());
-                            Integer lv = pdc.get(key, PersistentDataType.INTEGER);
-                            int effLevel = (lv == null ? 0 : lv);
-                            if (effLevel > 0) {
-                                CustomEffect ce = Effects.get(effectId);
-                                String name = (ce != null ? ce.displayName() : effectId);
-                                if (!name.isEmpty()) name = name.substring(0,1).toUpperCase(Locale.ROOT) + name.substring(1);
-                                specialLines.add(ChatColor.LIGHT_PURPLE + " - " + name + " " + roman(effLevel));
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (!specialLines.isEmpty()) {
-                lore.add(ChatColor.GRAY + " ");
-                lore.add(ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "Special Enchants:");
-                lore.addAll(specialLines);
-            }
-
-            meta.setLore(lore);
-            display.setItemMeta(meta);
-        }
+        ItemStack display = GuiItemUtil.forDisplay(plugin, it);
+        if (display == null) return;
 
         for (int i = 0; i < inv.getSize(); i++) {
             if (inv.getItem(i) == null || inv.getItem(i).getType() == Material.AIR) {

--- a/SpecialItems/src/main/java/com/specialitems/util/GuiItemUtil.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/GuiItemUtil.java
@@ -1,0 +1,123 @@
+package com.specialitems.util;
+
+import com.specialitems.SpecialItemsPlugin;
+import com.specialitems.effects.CustomEffect;
+import com.specialitems.effects.Effects;
+import com.specialitems.leveling.LevelMath;
+import com.specialitems.leveling.ToolClass;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.*;
+
+/** Utility to build GUI display items for special items. */
+public final class GuiItemUtil {
+    private GuiItemUtil() {}
+
+    private static boolean hasSpecialPdc(ItemStack it) {
+        if (it == null) return false;
+        ItemMeta m = it.getItemMeta();
+        if (m == null) return false;
+        PersistentDataContainer pdc = m.getPersistentDataContainer();
+        if (pdc == null) return false;
+        for (NamespacedKey key : pdc.getKeys()) {
+            String k = key.getKey();
+            if (k != null && k.startsWith("ench_")) return true;
+        }
+        return false;
+    }
+
+    private static String prettyVanilla(Enchantment e) {
+        String key = e.getKey().getKey().replace('_', ' ');
+        if (key.isEmpty()) return "Unknown";
+        return key.substring(0, 1).toUpperCase(Locale.ROOT) + key.substring(1);
+    }
+
+    /**
+     * Build a display item suitable for GUI views. Returns {@code null} if the item is not a special item.
+     */
+    public static ItemStack forDisplay(SpecialItemsPlugin plugin, ItemStack it) {
+        if (plugin == null || it == null || it.getType() == Material.AIR) return null;
+        var svc = plugin.leveling();
+        boolean special = svc.isSpecialItem(it) || hasSpecialPdc(it);
+        if (!special) return null;
+
+        int lvl = svc.getLevel(it);
+        double xp = svc.getXp(it);
+        double need = LevelMath.neededXpFor(lvl);
+
+        ItemStack display = it.clone();
+        ItemMeta meta = display.getItemMeta();
+        if (meta != null) {
+            try { meta.removeItemFlags(ItemFlag.values()); } catch (Throwable ignored) {}
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_UNBREAKABLE);
+            List<String> lore = new ArrayList<>();
+            lore.add(ChatColor.GOLD + "Level: " + ChatColor.YELLOW + lvl);
+            lore.add(ChatColor.GOLD + "XP: " + ChatColor.YELLOW + String.format("%.1f", xp) + ChatColor.GRAY + " / " + ChatColor.YELLOW + String.format("%.1f", need));
+            if (svc.detectToolClass(it) == ToolClass.HOE) {
+                double by = svc.getBonusYieldPct(it);
+                lore.add(ChatColor.GOLD + "Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
+            }
+
+            Map<Enchantment, Integer> enchants = it.getEnchantments();
+            if (!enchants.isEmpty()) {
+                lore.add(ChatColor.GRAY + " ");
+                lore.add(ChatColor.BLUE + "" + ChatColor.BOLD + "Vanilla Enchants:");
+                for (Map.Entry<Enchantment, Integer> en : enchants.entrySet()) {
+                    lore.add(ChatColor.BLUE + " - " + prettyVanilla(en.getKey()) + " " + ItemUtil.roman(en.getValue()));
+                }
+            }
+
+            List<String> specialLines = new ArrayList<>();
+            for (String id : Effects.ids()) {
+                int elv = 0;
+                try { elv = ItemUtil.getEffectLevel(it, id); } catch (Throwable ignored) {}
+                if (elv > 0) {
+                    CustomEffect ce = Effects.get(id);
+                    String name = (ce != null ? ce.displayName() : id);
+                    if (!name.isEmpty()) name = name.substring(0, 1).toUpperCase(Locale.ROOT) + name.substring(1);
+                    specialLines.add(ChatColor.LIGHT_PURPLE + " - " + name + " " + ItemUtil.roman(elv));
+                }
+            }
+
+            if (specialLines.isEmpty()) {
+                PersistentDataContainer pdc = meta.getPersistentDataContainer();
+                if (pdc != null) {
+                    for (NamespacedKey key : pdc.getKeys()) {
+                        String k = key.getKey();
+                        if (k != null && k.startsWith("ench_")) {
+                            String effectId = k.substring("ench_".length());
+                            Integer lv = pdc.get(key, PersistentDataType.INTEGER);
+                            int effLevel = (lv == null ? 0 : lv);
+                            if (effLevel > 0) {
+                                CustomEffect ce = Effects.get(effectId);
+                                String name = (ce != null ? ce.displayName() : effectId);
+                                if (!name.isEmpty()) name = name.substring(0, 1).toUpperCase(Locale.ROOT) + name.substring(1);
+                                specialLines.add(ChatColor.LIGHT_PURPLE + " - " + name + " " + ItemUtil.roman(effLevel));
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!specialLines.isEmpty()) {
+                lore.add(ChatColor.GRAY + " ");
+                lore.add(ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "Special Enchants:");
+                lore.addAll(specialLines);
+            }
+
+            lore.add(ChatColor.GRAY + " ");
+            lore.add(ChatColor.GOLD + "Unbreakable");
+            meta.setLore(lore);
+            display.setItemMeta(meta);
+        }
+        return display;
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/util/Tagger.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/Tagger.java
@@ -1,7 +1,6 @@
 package com.specialitems.util;
 
 import com.specialitems.leveling.Keys;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -28,9 +27,6 @@ public final class Tagger {
 
         meta.setUnbreakable(true);
         try { meta.addItemFlags(ItemFlag.HIDE_UNBREAKABLE, ItemFlag.HIDE_ENCHANTS); } catch (Throwable ignored) {}
-        if (meta.getEnchants().isEmpty()) {
-            try { meta.addEnchant(Enchantment.UNBREAKING, 1, true); } catch (Throwable ignored) {}
-        }
 
         item.setItemMeta(meta);
     }

--- a/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
@@ -1,6 +1,5 @@
 package com.specialitems.util;
 
-import com.specialitems.effects.Effects;
 import com.specialitems.SpecialItemsPlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -39,17 +38,6 @@ public final class TemplateItems {
             List<String> lore = new ArrayList<>();
             for (String l : t.getStringList("lore")) lore.add(ChatColor.translateAlternateColorCodes('&', l));
 
-            var enchSec = t.getConfigurationSection("enchants");
-            if (enchSec != null && !enchSec.getKeys(false).isEmpty()) {
-                lore.add(ChatColor.DARK_GRAY + "" + ChatColor.STRIKETHROUGH + "----------------");
-                lore.add(ChatColor.GRAY + "Effects:");
-                for (String eid : enchSec.getKeys(false)) {
-                    int lvl = enchSec.getInt(eid, 1);
-                    var eff = Effects.get(eid);
-                    String disp = eff != null ? eff.displayName() : eid;
-                    lore.add(ChatColor.DARK_AQUA + " - " + ChatColor.AQUA + disp + " " + ItemUtil.roman(lvl));
-                }
-            }
             meta.setLore(lore);
             it.setItemMeta(meta);
         }


### PR DESCRIPTION
## Summary
- Remove default unbreaking enchant from tagged special items
- Show special items consistently across GUIs with unified lore and orange Unbreakable line
- Drop template 'Effects' section to avoid duplicated enchant listings

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a21da039ec832594c20cedb3b847d2