### PR TITLE
Add menu and list GUIs for factories command

### DIFF
--- a/LootFactory-src/src/main/java/com/lootfactory/command/FactoriesCommand.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/command/FactoriesCommand.java
@@ -2,9 +2,8 @@ package com.lootfactory.command;
 
 import com.lootfactory.factory.FactoryDef;
 import com.lootfactory.factory.FactoryManager;
-import com.lootfactory.gui.FactoryTypesGUI;
+import com.lootfactory.gui.FactoriesGUI;
 import com.lootfactory.util.Msg;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -30,7 +29,7 @@ public class FactoriesCommand implements CommandExecutor {
                 p.sendMessage(Msg.prefix() + Msg.color("&cNo permission."));
                 return true;
             }
-            FactoryTypesGUI.open(p, manager);
+            FactoriesGUI.open(p, manager);
             return true;
         }
 

--- a/LootFactory-src/src/main/java/com/lootfactory/command/FactoryCommand.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/command/FactoryCommand.java
@@ -1,27 +1,91 @@
 package com.lootfactory.command;
-import com.lootfactory.LootFactoryPlugin; import com.lootfactory.factory.FactoryDef; import com.lootfactory.factory.FactoryManager; import com.lootfactory.util.Msg;
-import org.bukkit.Bukkit; import org.bukkit.ChatColor; import org.bukkit.command.*; import org.bukkit.entity.Player; import org.jetbrains.annotations.NotNull;
+
+import com.lootfactory.LootFactoryPlugin;
+import com.lootfactory.factory.FactoryDef;
+import com.lootfactory.factory.FactoryManager;
+import com.lootfactory.gui.FactoryTypesGUI;
+import com.lootfactory.util.Msg;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
 public class FactoryCommand implements CommandExecutor {
-  private final FactoryManager manager; public FactoryCommand(FactoryManager manager){ this.manager=manager; }
-  @Override public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args){
-    if(!sender.hasPermission("lootfactory.admin")){ sender.sendMessage(Msg.prefix()+Msg.color("&cNo permission.")); return true; }
-    if(args.length==0){
-      sender.sendMessage(Msg.color("&e/factory give <player> <type> [level]"));
-      sender.sendMessage(Msg.color("&e/factory reload"));
-      sender.sendMessage(Msg.color("&e/factories"));
-      return true;
+
+    private final FactoryManager manager;
+
+    public FactoryCommand(FactoryManager manager) {
+        this.manager = manager;
     }
-    switch(args[0].toLowerCase()){
-      case "give": {
-        if(args.length<3){ sender.sendMessage(Msg.color("&cUsage: /factory give <player> <type> [level]")); return true; }
-        Player target=Bukkit.getPlayer(args[1]); if(target==null){ sender.sendMessage(Msg.color("&cPlayer not found.")); return true; }
-        String type=args[2].toUpperCase(); FactoryDef def=manager.getDef(type); if(def==null){ sender.sendMessage(Msg.color("&cUnknown factory type. Use /factories")); return true; }
-        int level=1; if(args.length>=4){ try{ level=Math.max(1,Integer.parseInt(args[3])); }catch(Exception ignored){} }
-        target.getInventory().addItem(manager.createFactoryItem(target.getUniqueId(), type, level, 0d));
-        sender.sendMessage(Msg.prefix()+Msg.color("&aGave &e"+def.display+" &7(Level "+level+") to &e"+target.getName())); return true;
-      }
-      case "reload": { LootFactoryPlugin.get().reloadConfig(); sender.sendMessage(Msg.prefix()+Msg.color("&aConfig reloaded.")); return true; }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender,
+                             @NotNull Command command,
+                             @NotNull String label,
+                             @NotNull String[] args) {
+        if (args.length == 0) {
+            sender.sendMessage(Msg.color("&e/factory give <player> <type> [level]"));
+            sender.sendMessage(Msg.color("&e/factory reload"));
+            sender.sendMessage(Msg.color("&e/factory listtypes"));
+            sender.sendMessage(Msg.color("&e/factories"));
+            return true;
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "give": {
+                if (!sender.hasPermission("lootfactory.admin")) {
+                    sender.sendMessage(Msg.prefix() + Msg.color("&cNo permission."));
+                    return true;
+                }
+                if (args.length < 3) {
+                    sender.sendMessage(Msg.color("&cUsage: /factory give <player> <type> [level]"));
+                    return true;
+                }
+                Player target = Bukkit.getPlayer(args[1]);
+                if (target == null) {
+                    sender.sendMessage(Msg.color("&cPlayer not found."));
+                    return true;
+                }
+                String type = args[2].toUpperCase();
+                FactoryDef def = manager.getDef(type);
+                if (def == null) {
+                    sender.sendMessage(Msg.color("&cUnknown factory type. Use /factories"));
+                    return true;
+                }
+                int level = 1;
+                if (args.length >= 4) {
+                    try {
+                        level = Math.max(1, Integer.parseInt(args[3]));
+                    } catch (Exception ignored) { }
+                }
+                target.getInventory().addItem(manager.createFactoryItem(target.getUniqueId(), type, level, 0d));
+                sender.sendMessage(Msg.prefix() + Msg.color("&aGave &e" + def.display + " &7(Level " + level + ") to &e" + target.getName()));
+                return true;
+            }
+            case "reload": {
+                if (!sender.hasPermission("lootfactory.admin")) {
+                    sender.sendMessage(Msg.prefix() + Msg.color("&cNo permission."));
+                    return true;
+                }
+                LootFactoryPlugin.get().reloadConfig();
+                sender.sendMessage(Msg.prefix() + Msg.color("&aConfig reloaded."));
+                return true;
+            }
+            case "listtypes": {
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage("Players only.");
+                    return true;
+                }
+                Player p = (Player) sender;
+                FactoryTypesGUI.open(p, manager);
+                return true;
+            }
+            default:
+                sender.sendMessage(Msg.color("&cUnknown subcommand."));
+                return true;
+        }
     }
-    return true;
-  }
 }
+

--- a/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryManager.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryManager.java
@@ -195,6 +195,10 @@ public class FactoryManager {
     public int countPlaced(UUID player) { return (int) byOwner.getOrDefault(player, Collections.emptySet()).stream().filter(fi -> fi.location != null).count(); }
     public boolean canPlace(UUID player) { return countPlaced(player) < calcMaxSlots(player); }
 
+    public Collection<FactoryInstance> getFactories(UUID owner) {
+        return Collections.unmodifiableCollection(byOwner.getOrDefault(owner, Collections.emptySet()));
+    }
+
     /* ====== Item creation / reading ====== */
 
     public ItemStack createFactoryItem(String typeId, int level, double xpSeconds, int prestige) {

--- a/LootFactory-src/src/main/java/com/lootfactory/gui/FactoriesGUI.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/gui/FactoriesGUI.java
@@ -1,0 +1,73 @@
+package com.lootfactory.gui;
+
+import com.lootfactory.factory.FactoryManager;
+import com.lootfactory.util.Msg;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Arrays;
+
+/**
+ * Main menu for factory-related features.
+ */
+public class FactoriesGUI {
+
+    public static void open(Player p, FactoryManager manager){
+        Inventory inv = Bukkit.createInventory(new MenuView(manager), 27, ChatColor.BLUE + "Factories");
+        render(inv);
+        p.openInventory(inv);
+    }
+
+    private static void render(Inventory inv){
+        inv.clear();
+
+        ItemStack shop = new ItemStack(Material.EMERALD);
+        ItemMeta sm = shop.getItemMeta();
+        sm.setDisplayName(Msg.color("&aFactory Shop"));
+        sm.setLore(Arrays.asList(Msg.color("&7Buy new factories")));
+        shop.setItemMeta(sm);
+        inv.setItem(11, shop);
+
+        ItemStack types = new ItemStack(Material.CHEST);
+        ItemMeta tm = types.getItemMeta();
+        tm.setDisplayName(Msg.color("&aAll Factory Types"));
+        tm.setLore(Arrays.asList(Msg.color("&7View all available factories")));
+        types.setItemMeta(tm);
+        inv.setItem(13, types);
+
+        ItemStack mine = new ItemStack(Material.FURNACE);
+        ItemMeta mm = mine.getItemMeta();
+        mm.setDisplayName(Msg.color("&aYour Factories"));
+        mm.setLore(Arrays.asList(Msg.color("&7View your active factories")));
+        mine.setItemMeta(mm);
+        inv.setItem(15, mine);
+    }
+
+    public static class MenuView implements InventoryHolder {
+        private final FactoryManager manager;
+        public MenuView(FactoryManager manager){ this.manager = manager; }
+        @Override public Inventory getInventory(){ return Bukkit.createInventory(this, 27); }
+        public void onClick(InventoryClickEvent e){
+            e.setCancelled(true);
+            if(!(e.getWhoClicked() instanceof Player)) return;
+            Player p = (Player)e.getWhoClicked();
+            int slot = e.getRawSlot();
+            if(slot == 11){
+                ShopGUI.open(p, manager);
+            } else if(slot == 13){
+                FactoryTypesGUI.open(p, manager);
+            } else if(slot == 15){
+                FactoryListGUI.open(p, manager);
+            }
+        }
+        public void onClose(InventoryCloseEvent e){ }
+    }
+}

--- a/LootFactory-src/src/main/java/com/lootfactory/gui/FactoryListGUI.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/gui/FactoryListGUI.java
@@ -1,0 +1,71 @@
+package com.lootfactory.gui;
+
+import com.lootfactory.factory.FactoryInstance;
+import com.lootfactory.factory.FactoryManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * GUI listing a player's active factories.
+ */
+public class FactoryListGUI {
+
+    public static void open(Player p, FactoryManager manager, UUID owner){
+        Inventory inv = Bukkit.createInventory(new ListView(manager, owner), 54, ChatColor.GREEN + "Your Factories");
+        render(inv, manager, owner);
+        p.openInventory(inv);
+    }
+
+    public static void open(Player p, FactoryManager manager){
+        open(p, manager, p.getUniqueId());
+    }
+
+    private static void render(Inventory inv, FactoryManager manager, UUID owner){
+        inv.clear();
+        int slot = 0;
+        List<FactoryInstance> list = new ArrayList<>(manager.getFactories(owner));
+        for(FactoryInstance fi : list){
+            if(slot >= inv.getSize()) break;
+            ItemStack it = manager.createFactoryItem(fi.typeId, fi.level, fi.xpSeconds, fi.prestige);
+            inv.setItem(slot++, it);
+        }
+    }
+
+    public static class ListView implements InventoryHolder {
+        private final FactoryManager manager;
+        private final List<FactoryInstance> list;
+        public ListView(FactoryManager manager, UUID owner){
+            this.manager = manager;
+            this.list = new ArrayList<>(manager.getFactories(owner));
+        }
+        @Override public Inventory getInventory(){ return Bukkit.createInventory(this, 54); }
+        public void onClick(InventoryClickEvent e){
+            if(e.getView().getTopInventory().equals(e.getClickedInventory())
+                    || e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
+                    || e.getAction() == InventoryAction.HOTBAR_SWAP
+                    || e.getAction() == InventoryAction.HOTBAR_MOVE_AND_READD
+                    || e.getAction() == InventoryAction.COLLECT_TO_CURSOR){
+                e.setCancelled(true);
+                if(e.getWhoClicked() instanceof Player){
+                    int slot = e.getRawSlot();
+                    if(slot >= 0 && slot < list.size()){
+                        FactoryInstance fi = list.get(slot);
+                        FactoryGUI.open((Player)e.getWhoClicked(), manager, fi);
+                    }
+                }
+            }
+        }
+        public void onClose(InventoryCloseEvent e){ }
+    }
+}

--- a/LootFactory-src/src/main/java/com/lootfactory/gui/FactoryTypesGUI.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/gui/FactoryTypesGUI.java
@@ -2,19 +2,24 @@ package com.lootfactory.gui;
 
 import com.lootfactory.factory.FactoryDef;
 import com.lootfactory.factory.FactoryManager;
+import com.lootfactory.factory.FactoryRarity;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Read-only GUI that lists all available factory types.
@@ -30,17 +35,29 @@ public class FactoryTypesGUI {
 
     private static void render(Inventory inv, FactoryManager manager){
         inv.clear();
-        // Sort by rarity weight (ordinal) then display/name
-        List<FactoryDef> defs = new ArrayList<>(manager.getAllDefs());
-        defs.sort(Comparator
-                .comparing((FactoryDef d) -> d.rarity.ordinal())
-                .thenComparing(d -> d.display != null ? d.display : d.id, String.CASE_INSENSITIVE_ORDER));
 
-        int slot = 0;
-        for (FactoryDef def : defs){
-            if (slot >= inv.getSize()) break;
-            ItemStack it = manager.createFactoryItem(def.id, 1, 0d, 0);
-            inv.setItem(slot++, it);
+        Map<FactoryRarity, List<FactoryDef>> grouped = new EnumMap<>(FactoryRarity.class);
+        for (FactoryDef def : manager.getAllDefs()) {
+            grouped.computeIfAbsent(def.rarity, r -> new ArrayList<>()).add(def);
+        }
+
+        for (FactoryRarity r : FactoryRarity.values()) {
+            List<FactoryDef> list = grouped.getOrDefault(r, Collections.emptyList());
+            list.sort(Comparator.comparing(d -> d.display != null ? d.display : d.id, String.CASE_INSENSITIVE_ORDER));
+
+            int start = r.ordinal() * 9 + (9 - list.size()) / 2;
+            for (FactoryDef def : list) {
+                if (start >= (r.ordinal() + 1) * 9) break;
+                ItemStack it = manager.createFactoryItem(def.id, 1, 0d, 0);
+                ItemMeta meta = it.getItemMeta();
+                if (meta != null && meta.hasLore()) {
+                    List<String> lore = new ArrayList<>(meta.getLore());
+                    lore.removeIf(line -> ChatColor.stripColor(line).startsWith("Type:"));
+                    meta.setLore(lore);
+                    it.setItemMeta(meta);
+                }
+                inv.setItem(start++, it);
+            }
         }
     }
 
@@ -51,7 +68,10 @@ public class FactoryTypesGUI {
         @Override public Inventory getInventory(){ return Bukkit.createInventory(this, 54); }
         public void onClick(InventoryClickEvent e){
             if (e.getView().getTopInventory().equals(e.getClickedInventory())
-                    || e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
+                    || e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY
+                    || e.getAction() == InventoryAction.HOTBAR_SWAP
+                    || e.getAction() == InventoryAction.HOTBAR_MOVE_AND_READD
+                    || e.getAction() == InventoryAction.COLLECT_TO_CURSOR) {
                 e.setCancelled(true);
             }
         }

--- a/LootFactory-src/src/main/java/com/lootfactory/gui/GUIListener.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/gui/GUIListener.java
@@ -1,10 +1,42 @@
 package com.lootfactory.gui;
-import org.bukkit.event.*; import org.bukkit.event.inventory.*;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.InventoryHolder;
+
 public class GUIListener implements Listener {
-  @EventHandler public void onClick(InventoryClickEvent e){ if(e.getView().getTopInventory().getHolder() instanceof FactoryView) ((FactoryView)e.getView().getTopInventory().getHolder()).onClick(e);
-    else if(e.getView().getTopInventory().getHolder() instanceof ShopView) ((ShopView)e.getView().getTopInventory().getHolder()).onClick(e);
-    else if(e.getView().getTopInventory().getHolder() instanceof FactoryTypesGUI.TypesView) ((FactoryTypesGUI.TypesView)e.getView().getTopInventory().getHolder()).onClick(e); }
-  @EventHandler public void onClose(InventoryCloseEvent e){ if(e.getInventory().getHolder() instanceof FactoryView) ((FactoryView)e.getInventory().getHolder()).onClose(e);
-    else if(e.getInventory().getHolder() instanceof ShopView) ((ShopView)e.getInventory().getHolder()).onClose(e);
-    else if(e.getInventory().getHolder() instanceof FactoryTypesGUI.TypesView) ((FactoryTypesGUI.TypesView)e.getInventory().getHolder()).onClose(e); }
+  @EventHandler
+  public void onClick(InventoryClickEvent e){
+    InventoryHolder h = e.getView().getTopInventory().getHolder();
+    if(h instanceof FactoryView) ((FactoryView)h).onClick(e);
+    else if(h instanceof ShopView) ((ShopView)h).onClick(e);
+    else if(h instanceof FactoryTypesGUI.TypesView) ((FactoryTypesGUI.TypesView)h).onClick(e);
+    else if(h instanceof FactoriesGUI.MenuView) ((FactoriesGUI.MenuView)h).onClick(e);
+    else if(h instanceof FactoryListGUI.ListView) ((FactoryListGUI.ListView)h).onClick(e);
+  }
+
+  @EventHandler
+  public void onClose(InventoryCloseEvent e){
+    InventoryHolder h = e.getInventory().getHolder();
+    if(h instanceof FactoryView) ((FactoryView)h).onClose(e);
+    else if(h instanceof ShopView) ((ShopView)h).onClose(e);
+    else if(h instanceof FactoryTypesGUI.TypesView) ((FactoryTypesGUI.TypesView)h).onClose(e);
+    else if(h instanceof FactoriesGUI.MenuView) ((FactoriesGUI.MenuView)h).onClose(e);
+    else if(h instanceof FactoryListGUI.ListView) ((FactoryListGUI.ListView)h).onClose(e);
+  }
+
+  @EventHandler
+  public void onDrag(InventoryDragEvent e){
+    InventoryHolder h = e.getView().getTopInventory().getHolder();
+    if(h instanceof FactoryView || h instanceof ShopView ||
+       h instanceof FactoryTypesGUI.TypesView || h instanceof FactoriesGUI.MenuView ||
+       h instanceof FactoryListGUI.ListView){
+      if(e.getRawSlots().stream().anyMatch(slot -> slot < e.getView().getTopInventory().getSize())){
+        e.setCancelled(true);
+      }
+    }
+  }
 }

--- a/LootFactory-src/src/main/resources/plugin.yml
+++ b/LootFactory-src/src/main/resources/plugin.yml
@@ -10,7 +10,7 @@ commands:
     description: Prestige a factory
     permission: lootfactory.prestige
   factory:
-    permission: lootfactory.admin
+    description: Factory utilities
   factoryshop:
     permission: lootfactory.shop
   factories:


### PR DESCRIPTION
## Summary
- add main `/factories` menu with links to shop, available types, and owned factories
- implement GUI to show a player's active factories and open factory details
- expand listeners and utilities to support new GUIs and block item removal
- expose `/factory listtypes` to players and group types by rarity in a read-only GUI

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a46959dbfc83259e8a8e8925aa6a29