### PR TITLE
Add new factory types across rarities and Insane tier

### DIFF
--- a/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryDef.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryDef.java
@@ -11,7 +11,7 @@ public class FactoryDef {
     public final Material material;
     public final double baseAmount;
     public final double baseIntervalSec;
-    public final FactoryRarity rarity;       // COMMON / UNCOMMON / RARE / EPIC / LEGENDARY
+    public final FactoryRarity rarity;       // COMMON / UNCOMMON / RARE / EPIC / LEGENDARY / INSANE
     public final double yieldBonusPct;       // e.g. 20.0 for +20% yield
     public final double speedBonusPct;       // e.g. 15.0 for +15% speed
 

--- a/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryManager.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryManager.java
@@ -320,8 +320,9 @@ public class FactoryManager {
             case COMMON: return "&7";
             case UNCOMMON: return "&a";
             case RARE: return "&9";
-            case EPIC: return "&d";
+            case EPIC: return "&5";
             case LEGENDARY: return "&6";
+            case INSANE: return "&d";
             default: return "&f";
         }
     }

--- a/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryRarity.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/factory/FactoryRarity.java
@@ -1,2 +1,10 @@
-package com.lootfactory.factory; 
-public enum FactoryRarity { COMMON, UNCOMMON, RARE, EPIC, LEGENDARY }
+package com.lootfactory.factory;
+
+public enum FactoryRarity {
+    COMMON,
+    UNCOMMON,
+    RARE,
+    EPIC,
+    LEGENDARY,
+    INSANE
+}

--- a/LootFactory-src/src/main/java/com/lootfactory/gui/FactoryTypesGUI.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/gui/FactoryTypesGUI.java
@@ -41,13 +41,16 @@ public class FactoryTypesGUI {
             grouped.computeIfAbsent(def.rarity, r -> new ArrayList<>()).add(def);
         }
 
-        for (FactoryRarity r : FactoryRarity.values()) {
+        FactoryRarity[] order = FactoryRarity.values();
+        for (int idx = 0; idx < order.length; idx++) {
+            FactoryRarity r = order[idx];
             List<FactoryDef> list = grouped.getOrDefault(r, Collections.emptyList());
             list.sort(Comparator.comparing(d -> d.display != null ? d.display : d.id, String.CASE_INSENSITIVE_ORDER));
 
-            int start = r.ordinal() * 9 + (9 - list.size()) / 2;
+            int row = order.length - 1 - idx;
+            int start = row * 9 + (9 - list.size()) / 2;
             for (FactoryDef def : list) {
-                if (start >= (r.ordinal() + 1) * 9) break;
+                if (start >= (row + 1) * 9) break;
                 ItemStack it = manager.createFactoryItem(def.id, 1, 0d, 0);
                 ItemMeta meta = it.getItemMeta();
                 if (meta != null && meta.hasLore()) {

--- a/LootFactory-src/src/main/java/com/lootfactory/gui/ShopGUI.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/gui/ShopGUI.java
@@ -31,7 +31,7 @@ public class ShopGUI {
     m1.setDisplayName(Msg.color("&aBuy Random Factory"));
     List<String> lore1 = new ArrayList<>();
     lore1.add(Msg.color("&7Price: &e" + cur + String.format("%.2f", price)));
-    lore1.add(Msg.color("&8Legendary factories are very rare!"));
+    lore1.add(Msg.color("&8Legendary factories are very rare! &dInsane &8factories are extremely rare!"));
     m1.setLore(lore1);
     buy1.setItemMeta(m1);
     inv.setItem(13, buy1);

--- a/LootFactory-src/src/main/java/com/lootfactory/util/Cfg.java
+++ b/LootFactory-src/src/main/java/com/lootfactory/util/Cfg.java
@@ -5,10 +5,11 @@ public class Cfg {
   public static Map<FactoryRarity, Double> getRarityWeights(FileConfiguration c){
     Map<FactoryRarity,Double> m=new EnumMap<>(FactoryRarity.class);
     m.put(FactoryRarity.COMMON, c.getDouble("shop.weights.COMMON",0.55));
-    m.put(FactoryRarity.UNCOMMON, c.getDouble("shop.weights.UNCOMMON",0.25));
-    m.put(FactoryRarity.RARE, c.getDouble("shop.weights.RARE",0.12));
-    m.put(FactoryRarity.EPIC, c.getDouble("shop.weights.EPIC",0.06));
-    m.put(FactoryRarity.LEGENDARY, c.getDouble("shop.weights.LEGENDARY",0.02));
+    m.put(FactoryRarity.UNCOMMON, c.getDouble("shop.weights.UNCOMMON",0.26));
+    m.put(FactoryRarity.RARE, c.getDouble("shop.weights.RARE",0.13));
+    m.put(FactoryRarity.EPIC, c.getDouble("shop.weights.EPIC",0.05));
+    m.put(FactoryRarity.LEGENDARY, c.getDouble("shop.weights.LEGENDARY",0.009));
+    m.put(FactoryRarity.INSANE, c.getDouble("shop.weights.INSANE",0.001));
     double sum=0; for(double v:m.values()) sum+=v; if(sum>0){ for(FactoryRarity r:m.keySet()) m.put(r, m.get(r)/sum); } return m;
   }
 }

--- a/LootFactory-src/src/main/resources/config.yml
+++ b/LootFactory-src/src/main/resources/config.yml
@@ -15,7 +15,7 @@ pickup_button_slot: 15
 shop:
   enabled: true
   price: 10000.0
-  weights: { COMMON: 0.55, UNCOMMON: 0.26, RARE: 0.13, EPIC: 0.05, LEGENDARY: 0.01 }
+  weights: { COMMON: 0.55, UNCOMMON: 0.26, RARE: 0.13, EPIC: 0.05, LEGENDARY: 0.009, INSANE: 0.001 }
 
 factories:
   # ---------- COMMON (10) ----------
@@ -30,7 +30,7 @@ factories:
   REDSTONE_REACTOR:     { display: "Redstone Reactor",     material: "REDSTONE_LAMP",   base_amount: 8.0,  base_interval_seconds: 10.0, rarity: "COMMON",    yield_bonus_pct: 3,  speed_bonus_pct: 6  }
   WHEAT_WINNOWER:       { display: "Wheat Winnower",       material: "LOOM",            base_amount: 8.0,  base_interval_seconds: 10.0, rarity: "COMMON",    yield_bonus_pct: 6,  speed_bonus_pct: 2  }
 
-  # ---------- UNCOMMON (8) ----------
+  # ---------- UNCOMMON (9) ----------
   GOLD_FORGE:           { display: "Gold Forge",           material: "SMOKER",          base_amount: 10.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 10, speed_bonus_pct: 0  }
   EMERALD_REFINERY:     { display: "Emerald Refinery",     material: "GRINDSTONE",      base_amount: 12.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 12, speed_bonus_pct: 0  }
   BLAZE_SMELTER:        { display: "Blaze Smelter",        material: "FURNACE",         base_amount: 13.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 0,  speed_bonus_pct: 12 }
@@ -39,24 +39,31 @@ factories:
   AMETHYST_ASSEMBLER:   { display: "Amethyst Assembler",   material: "SMITHING_TABLE",  base_amount: 13.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 12, speed_bonus_pct: 6  }
   SLIME_STABILIZER:     { display: "Slime Stabilizer",     material: "BREWING_STAND",   base_amount: 11.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 14, speed_bonus_pct: 5  }
   HONEY_HARVESTER:      { display: "Honey Harvester",      material: "CARTOGRAPHY_TABLE", base_amount: 13.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 10, speed_bonus_pct: 10 }
+  CORAL_CRUSHER:        { display: "Coral Crusher",        material: "STONECUTTER",     base_amount: 12.0, base_interval_seconds: 10.0, rarity: "UNCOMMON",  yield_bonus_pct: 11, speed_bonus_pct: 7  }
 
-  # ---------- RARE (5) ----------
+  # ---------- RARE (7) ----------
   OBSIDIAN_PRESS:       { display: "Obsidian Press",       material: "ANVIL",           base_amount: 15.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 12, speed_bonus_pct: 10 }
   ENDER_INFUSER:        { display: "Ender Infuser",        material: "ENCHANTING_TABLE",base_amount: 16.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 12, speed_bonus_pct: 15 }
   SHULKER_PRESS:        { display: "Shulker Press",        material: "ANVIL",           base_amount: 17.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 14, speed_bonus_pct: 12 }
   CHORUS_CULTIVATOR:    { display: "Chorus Cultivator",    material: "FLETCHING_TABLE", base_amount: 17.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 16, speed_bonus_pct: 10 }
   CRYO_QUARTZ_KILN:     { display: "Cryo Quartz Kiln",     material: "BLAST_FURNACE",   base_amount: 18.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 16, speed_bonus_pct: 14 }
+  WITHER_WORKSHOP:      { display: "Wither Workshop",      material: "SMITHING_TABLE",  base_amount: 18.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 16, speed_bonus_pct: 14 }
+  PHANTOM_DISTILLERY:   { display: "Phantom Distillery",   material: "BREWING_STAND",    base_amount: 17.0, base_interval_seconds: 10.0, rarity: "RARE",      yield_bonus_pct: 15, speed_bonus_pct: 13 }
 
-  # ---------- EPIC (4) ----------
+  # ---------- EPIC (5) ----------
   DIAMOND_PROCESSOR:    { display: "Diamond Processor",    material: "SMITHING_TABLE",  base_amount: 20.0, base_interval_seconds: 10.0, rarity: "EPIC",      yield_bonus_pct: 18, speed_bonus_pct: 15 }
   NETHER_STAR_FORGE:    { display: "Nether Star Forge",    material: "BEACON",          base_amount: 22.0, base_interval_seconds: 10.0, rarity: "EPIC",      yield_bonus_pct: 18, speed_bonus_pct: 18 }
   DRAGON_GLASS_FORGE:   { display: "Dragon Glass Forge",   material: "BLAST_FURNACE",   base_amount: 23.0, base_interval_seconds: 10.0, rarity: "EPIC",      yield_bonus_pct: 20, speed_bonus_pct: 18 }
   CELESTIAL_FOUNDRY:    { display: "Celestial Foundry",    material: "LODESTONE",       base_amount: 24.0, base_interval_seconds: 10.0, rarity: "EPIC",      yield_bonus_pct: 20, speed_bonus_pct: 22 }
+  ECHO_EXTRACTOR:       { display: "Echo Extractor",       material: "SCULK_CATALYST",  base_amount: 21.0, base_interval_seconds: 10.0, rarity: "EPIC",      yield_bonus_pct: 19, speed_bonus_pct: 17 }
 
   # ---------- LEGENDARY (3) ----------
   STARDUST_SYNTHESIZER: { display: "Stardust Synthesizer", material: "RESPAWN_ANCHOR",  base_amount: 25.0, base_interval_seconds: 10.0, rarity: "LEGENDARY", yield_bonus_pct: 22, speed_bonus_pct: 24 }
   ANCIENT_DEBRIS_REFINER: { display: "Ancient Debris Refiner", material: "NETHERITE_BLOCK", base_amount: 28.0, base_interval_seconds: 10.0, rarity: "LEGENDARY", yield_bonus_pct: 24, speed_bonus_pct: 24 }
   VOID_MATRIX:          { display: "Void Matrix",          material: "END_PORTAL_FRAME",     base_amount: 30.0, base_interval_seconds: 10.0, rarity: "LEGENDARY", yield_bonus_pct: 26, speed_bonus_pct: 28 }
+
+  # ---------- INSANE (1) ----------
+  INFINITY_CRYSTALIZER: { display: "Infinity Crystalizer", material: "END_CRYSTAL",     base_amount: 40.0, base_interval_seconds: 10.0, rarity: "INSANE", yield_bonus_pct: 35, speed_bonus_pct: 35 }
 
 prestige:
   perFactory:


### PR DESCRIPTION
## Summary
- add Coral Crusher uncommon factory
- add Wither Workshop & Phantom Distillery rare factories
- add Echo Extractor epic factory
- introduce Insane rarity with Infinity Crystalizer
- update rarity weights and color mappings
- reverse factory types GUI order so common is bottom and insane at top

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a48ce1414083258dabf08cbc64401e