### PR TITLE
Process farm and mine events even when cancelled

### DIFF
--- a/FarmXMine/src/main/java/com/instancednodes/nodes/NodeManager.java
+++ b/FarmXMine/src/main/java/com/instancednodes/nodes/NodeManager.java
@@ -54,8 +54,8 @@ public class NodeManager implements Listener {
         return na.equals(nb);
     }
 
-    // FARM: handle left-click harvest
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    // FARM: handle left-click harvest even if other plugins cancel the event
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onLeftClick(PlayerInteractEvent e) {
         if (e.getAction() != Action.LEFT_CLICK_BLOCK) return;
         Block b = e.getClickedBlock();
@@ -72,8 +72,8 @@ public class NodeManager implements Listener {
         }
     }
 
-    // MINE: process even if cancelled by other plugins (WG)
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    // MINE: process even if cancelled by other plugins (e.g. WorldGuard)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onBreak(BlockBreakEvent e) {
         Block b = e.getBlock();
         Location loc = b.getLocation();


### PR DESCRIPTION
## Summary
- allow farm harvesting to proceed even if other plugins cancel the interaction event
- allow mining with pickaxes when block break events are cancelled by protection plugins

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68a4974a3e5083259f6326d3d3981302