### PR TITLE
Rename plugin to FarmxMine and bypass protection cancellations

### DIFF
--- a/FarmXMine/build.gradle.kts
+++ b/FarmXMine/build.gradle.kts
@@ -23,5 +23,5 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.jar {
-    archiveFileName.set("InstancedNodes-${project.version}.jar")
+    archiveFileName.set("FarmxMine-${project.version}.jar")
 }

--- a/FarmXMine/src/main/java/com/instancednodes/nodes/NodeManager.java
+++ b/FarmXMine/src/main/java/com/instancednodes/nodes/NodeManager.java
@@ -54,8 +54,30 @@ public class NodeManager implements Listener {
         return na.equals(nb);
     }
 
-    // FARM: handle left-click harvest
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    // Allow other plugins like SpecialItems to see interactions in protected regions
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void uncancelInteract(PlayerInteractEvent e) {
+        if (e.getAction() != Action.LEFT_CLICK_BLOCK) return;
+        Block b = e.getClickedBlock();
+        if (b == null) return;
+        Location loc = b.getLocation();
+        boolean isMine = Cfg.MINE.contains(loc);
+        boolean isFarm = !isMine && Cfg.FARM.contains(loc);
+        if (!isMine && !isFarm) return;
+        e.setCancelled(false);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void uncancelBreak(BlockBreakEvent e) {
+        Block b = e.getBlock();
+        Location loc = b.getLocation();
+        if (Cfg.MINE.contains(loc) || Cfg.FARM.contains(loc)) {
+            e.setCancelled(false);
+        }
+    }
+
+    // FARM: handle left-click harvest even if other plugins cancel the event
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onLeftClick(PlayerInteractEvent e) {
         if (e.getAction() != Action.LEFT_CLICK_BLOCK) return;
         Block b = e.getClickedBlock();
@@ -72,8 +94,8 @@ public class NodeManager implements Listener {
         }
     }
 
-    // MINE: process even if cancelled by other plugins (WG)
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    // MINE: process even if cancelled by other plugins (e.g. WorldGuard)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = false)
     public void onBreak(BlockBreakEvent e) {
         Block b = e.getBlock();
         Location loc = b.getLocation();

--- a/FarmXMine/src/main/resources/plugin.yml
+++ b/FarmXMine/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: InstancedNodes
+name: FarmxMine
 main: com.instancednodes.InstancedNodesPlugin
 version: 0.4.6
 api-version: '1.21'


### PR DESCRIPTION
## Summary
- let SpecialItems tools trigger by un-cancelling farm/mine events even when protection plugins cancel them
- rename plugin and output jar to FarmxMine

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a4974a3e5083259f6326d3d3981302