### PR TITLE
Add leveling support for axes in SpecialItems

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
@@ -26,6 +26,7 @@ public final class LevelingService {
     public double xpSwordKill = 5.0;
     public double xpSwordBossKill = 25.0;
     public double xpHoeHarvest = 2.0;
+    public double xpAxeWood = 1.0;
 
     public double baseProcChance = 0.10; // 10%
     public double pityIncrement = 0.02;  // +2% per miss
@@ -54,6 +55,7 @@ public final class LevelingService {
         if (n.endsWith("_PICKAXE")) return ToolClass.PICKAXE;
         if (n.endsWith("_SWORD")) return ToolClass.SWORD;
         if (n.endsWith("_HOE")) return ToolClass.HOE;
+        if (n.endsWith("_AXE")) return ToolClass.AXE;
         return ToolClass.OTHER;
     }
 
@@ -130,6 +132,7 @@ public final class LevelingService {
                     case PICKAXE -> EnchantUtil.addOrIncrease(it, Enchantment.EFFICIENCY, 1, allowOverCapPickaxe);
                     case SWORD   -> EnchantUtil.addOrIncrease(it, Enchantment.SHARPNESS, 1, allowOverCapSword);
                     case HOE     -> setBonusYieldPct(it, getBonusYieldPct(it) + 10.0);
+                    case AXE     -> EnchantUtil.addOrIncrease(it, Enchantment.EFFICIENCY, 1, allowOverCapPickaxe);
                     default -> {}
                 }
                 PityCounter.reset(it, keys);

--- a/SpecialItems/src/main/java/com/specialitems/leveling/ToolClass.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/ToolClass.java
@@ -1,5 +1,5 @@
 package com.specialitems.leveling;
 
 public enum ToolClass {
-    PICKAXE, SWORD, HOE, OTHER
+    PICKAXE, SWORD, HOE, AXE, OTHER
 }


### PR DESCRIPTION
## Summary
- Handle `AXE` tool class in leveling service and listener
- Award XP for chopping logs and kills with special axes
- Grant efficiency enchantment to axes on level up
- Grant XP to special hoes when crop harvest interacts are cancelled

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0a676ac8325b2ce6e4b02679069