### PR TITLE
Integrate SpecialItems effects with FarmxMine regions

### DIFF
--- a/FarmXMine/src/main/java/com/instancednodes/InstancedNodesPlugin.java
+++ b/FarmXMine/src/main/java/com/instancednodes/InstancedNodesPlugin.java
@@ -7,6 +7,10 @@ import com.instancednodes.nodes.NodeManager;
 import com.instancednodes.util.Cfg;
 import com.instancednodes.util.Log;
 import com.instancednodes.util.Msg;
+import com.instancednodes.integration.RegionService;
+import com.instancednodes.integration.SpecialItemsApi;
+import com.instancednodes.integration.HarvestService;
+import com.instancednodes.integration.SpecialItemsIntegrationListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Random;
@@ -30,6 +34,15 @@ public class InstancedNodesPlugin extends JavaPlugin {
         this.dataManager = new DataManager(this);
         this.levelManager = new LevelManager(this);
         getServer().getPluginManager().registerEvents(new NodeManager(this), this);
+        if (Cfg.INTEGRATE_SPECIALITEMS) {
+            RegionService regionService = getServer().getServicesManager().load(RegionService.class);
+            SpecialItemsApi specialApi = getServer().getServicesManager().load(SpecialItemsApi.class);
+            HarvestService harvestService = getServer().getServicesManager().load(HarvestService.class);
+            if (regionService != null && specialApi != null && harvestService != null) {
+                getServer().getPluginManager().registerEvents(
+                        new SpecialItemsIntegrationListener(regionService, specialApi, harvestService), this);
+            }
+        }
         if (getCommand("nodes") != null) getCommand("nodes").setExecutor(new NodesCommand(this));
         if (getCommand("prestige") != null) getCommand("prestige").setExecutor(new PrestigeCommand(this));
         getLogger().info("InstancedNodes enabled v" + getDescription().getVersion());

--- a/FarmXMine/src/main/java/com/instancednodes/integration/HarvestService.java
+++ b/FarmXMine/src/main/java/com/instancednodes/integration/HarvestService.java
@@ -1,0 +1,42 @@
+package com.instancednodes.integration;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+/**
+ * Service encapsulating harvest logic so that respawn/instancing is handled
+ * consistently and no world drops are produced.
+ */
+public interface HarvestService {
+
+    /**
+     * Check whether the given block represents a mature crop.
+     */
+    boolean isMatureCrop(Block block);
+
+    /**
+     * Harvest a single block. Implementations must handle respawn/instancing
+     * and return the items and xp to be awarded.
+     */
+    HarvestResult harvestSingle(Player player, Block block, RegionType regionType, double yieldMultiplier);
+
+    /**
+     * Locate blocks affected by an AOE harvest.
+     */
+    List<Block> findAoeTargets(Block origin, RegionType regionType, int maxBlocks, int maxRadius);
+
+    /** Simple holder for harvest results. */
+    class HarvestResult {
+        public final List<ItemStack> drops;
+        public final int xp;
+
+        public HarvestResult(List<ItemStack> drops, int xp) {
+            this.drops = drops;
+            this.xp = xp;
+        }
+    }
+}
+

--- a/FarmXMine/src/main/java/com/instancednodes/integration/RegionService.java
+++ b/FarmXMine/src/main/java/com/instancednodes/integration/RegionService.java
@@ -1,0 +1,21 @@
+package com.instancednodes.integration;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+
+/**
+ * Service for resolving region types and material whitelist checks.
+ */
+public interface RegionService {
+
+    /**
+     * Determine the {@link RegionType} for a given location.
+     */
+    RegionType getRegionType(Location location);
+
+    /**
+     * Whether a material is allowed to be harvested in a region.
+     */
+    boolean isWhitelisted(RegionType type, Material material);
+}
+

--- a/FarmXMine/src/main/java/com/instancednodes/integration/RegionType.java
+++ b/FarmXMine/src/main/java/com/instancednodes/integration/RegionType.java
@@ -1,0 +1,11 @@
+package com.instancednodes.integration;
+
+/**
+ * Types of regions handled by FarmxMine.
+ */
+public enum RegionType {
+    NONE,
+    FARM,
+    MINE
+}
+

--- a/FarmXMine/src/main/java/com/instancednodes/integration/SpecialItemsApi.java
+++ b/FarmXMine/src/main/java/com/instancednodes/integration/SpecialItemsApi.java
@@ -1,0 +1,34 @@
+package com.instancednodes.integration;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Set;
+
+/**
+ * Abstraction over the SpecialItems plugin.
+ */
+public interface SpecialItemsApi {
+
+    /** Effects a special item can provide. */
+    enum Effect {
+        HARVESTER,
+        YIELD_MULTIPLIER,
+        REPLANT
+    }
+
+    /**
+     * Whether the provided item stack is managed by SpecialItems.
+     */
+    boolean isSpecialItem(ItemStack item);
+
+    /**
+     * Retrieve the set of effects active on the item.
+     */
+    Set<Effect> getEffects(ItemStack item);
+
+    /**
+     * Get the yield multiplier the item applies. Returns 1.0 if none.
+     */
+    double getYieldMultiplier(ItemStack item);
+}
+

--- a/FarmXMine/src/main/java/com/instancednodes/integration/SpecialItemsIntegrationListener.java
+++ b/FarmXMine/src/main/java/com/instancednodes/integration/SpecialItemsIntegrationListener.java
@@ -1,0 +1,109 @@
+package com.instancednodes.integration;
+
+import com.instancednodes.util.Cfg;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Integrates FarmxMine harvesting with SpecialItems effects.
+ */
+public class SpecialItemsIntegrationListener implements Listener {
+
+    private final RegionService regionService;
+    private final SpecialItemsApi specialApi;
+    private final HarvestService harvestService;
+
+    public SpecialItemsIntegrationListener(RegionService regionService,
+                                           SpecialItemsApi specialApi,
+                                           HarvestService harvestService) {
+        this.regionService = regionService;
+        this.specialApi = specialApi;
+        this.harvestService = harvestService;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onBlockBreak(BlockBreakEvent e) {
+        Block block = e.getBlock();
+        Player player = e.getPlayer();
+
+        RegionType rt = regionService.getRegionType(block.getLocation());
+        if (rt == RegionType.NONE) return;
+
+        if (!regionService.isWhitelisted(rt, block.getType())) {
+            e.setCancelled(true);
+            e.setDropItems(false);
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent("Hier nicht erlaubt"));
+            return;
+        }
+
+        e.setDropItems(false);
+
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        boolean special = specialApi.isSpecialItem(hand);
+        Set<SpecialItemsApi.Effect> effects = special
+                ? new HashSet<>(specialApi.getEffects(hand))
+                : Collections.emptySet();
+        double yieldMul = special ? specialApi.getYieldMultiplier(hand) : 1.0;
+
+        if (rt == RegionType.FARM && Cfg.DISABLE_REPLANT_IN_FARM) {
+            effects.remove(SpecialItemsApi.Effect.REPLANT);
+        }
+
+        if (special && effects.contains(SpecialItemsApi.Effect.HARVESTER)) {
+            List<Block> targets = harvestService.findAoeTargets(block, rt, Cfg.HARVESTER_MAX_BLOCKS, Cfg.HARVESTER_MAX_RADIUS);
+            for (Block t : targets) {
+                if (rt == RegionType.FARM && !harvestService.isMatureCrop(t)) continue;
+                HarvestService.HarvestResult r = harvestService.harvestSingle(player, t, rt, yieldMul);
+                giveDirectToInventory(player, r.drops);
+                addXp(player, r.xp);
+            }
+            e.setCancelled(true);
+            return;
+        }
+
+        if (rt == RegionType.FARM && !harvestService.isMatureCrop(block)) {
+            e.setCancelled(true);
+            return;
+        }
+
+        HarvestService.HarvestResult r = harvestService.harvestSingle(player, block, rt, yieldMul);
+        giveDirectToInventory(player, r.drops);
+        addXp(player, r.xp);
+        e.setCancelled(true);
+    }
+
+    private void giveDirectToInventory(Player player, List<ItemStack> drops) {
+        if (!Cfg.DIRECT_TO_INVENTORY) {
+            for (ItemStack it : drops) {
+                player.getWorld().dropItemNaturally(player.getLocation(), it);
+            }
+            return;
+        }
+        Map<Integer, ItemStack> leftover = new HashMap<>();
+        for (ItemStack it : drops) {
+            leftover.putAll(player.getInventory().addItem(it));
+        }
+        for (ItemStack it : leftover.values()) {
+            player.getWorld().dropItemNaturally(player.getLocation(), it);
+        }
+    }
+
+    private void addXp(Player player, int xp) {
+        player.giveExp(xp);
+    }
+}
+

--- a/FarmXMine/src/main/java/com/instancednodes/util/Cfg.java
+++ b/FarmXMine/src/main/java/com/instancednodes/util/Cfg.java
@@ -25,6 +25,12 @@ public class Cfg {
     public static boolean REQUIRE_PERMS;
     public static boolean OVERRIDE_CANCELLED;
 
+    public static boolean INTEGRATE_SPECIALITEMS;
+    public static boolean DISABLE_REPLANT_IN_FARM;
+    public static boolean DIRECT_TO_INVENTORY;
+    public static int HARVESTER_MAX_BLOCKS;
+    public static int HARVESTER_MAX_RADIUS;
+
     public static String[] VEIN_LORE;
     public static int VEIN_MAX_BLOCKS;
 
@@ -35,6 +41,12 @@ public class Cfg {
         RESPAWN_SECONDS = plugin.getConfig().getInt("respawn_seconds", 30);
         TARGET_HARVESTS = plugin.getConfig().getLong("target_harvests", 3000000L);
         EXPONENT = plugin.getConfig().getDouble("exponent", 1.6);
+
+        INTEGRATE_SPECIALITEMS = plugin.getConfig().getBoolean("farmxmine.integrate_specialitems", true);
+        DISABLE_REPLANT_IN_FARM = plugin.getConfig().getBoolean("farmxmine.disable_replant_in_farm", true);
+        DIRECT_TO_INVENTORY = plugin.getConfig().getBoolean("farmxmine.direct_to_inventory", true);
+        HARVESTER_MAX_BLOCKS = plugin.getConfig().getInt("harvester.max_blocks", 32);
+        HARVESTER_MAX_RADIUS = plugin.getConfig().getInt("harvester.max_radius", 5);
 
         PLAY_SOUNDS = plugin.getConfig().getBoolean("options.play_sounds", false);
         REQUIRE_PERMS = plugin.getConfig().getBoolean("options.require_permissions", false);

--- a/FarmXMine/src/main/resources/config.yml
+++ b/FarmXMine/src/main/resources/config.yml
@@ -5,6 +5,15 @@ respawn_seconds: 30
 target_harvests: 3000000
 exponent: 1.6
 
+farmxmine:
+  integrate_specialitems: true
+  disable_replant_in_farm: true
+  direct_to_inventory: true
+
+harvester:
+  max_blocks: 32
+  max_radius: 5
+
 options:
   play_sounds: false               # no sounds when harvesting (per request)
   require_permissions: false       # if true, players need instancednodes.mine/farm


### PR DESCRIPTION
## Summary
- add service abstractions and listener to route FarmxMine harvesting through SpecialItems effects
- load new integration config and register listener when services present
- support direct-to-inventory harvests, AOE harvester, and region whitelisting

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c872cba88325832b64d41b52e928