### PR TITLE
Refine farm/mine drops and special-item leveling

### DIFF
--- a/FarmXMine/src/main/java/com/instancednodes/integration/SpecialItemsIntegrationListener.java
+++ b/FarmXMine/src/main/java/com/instancednodes/integration/SpecialItemsIntegrationListener.java
@@ -37,22 +37,41 @@ public class SpecialItemsIntegrationListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     public void onBlockBreak(BlockBreakEvent e) {
+        if (e.isCancelled()) return;
         Block block = e.getBlock();
         Player player = e.getPlayer();
 
         RegionType rt = regionService.getRegionType(block.getLocation());
         if (rt == RegionType.NONE) return;
 
-        if (!regionService.isWhitelisted(rt, block.getType())) {
-            e.setCancelled(true);
-            e.setDropItems(false);
-            player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent("Hier nicht erlaubt"));
+        boolean bypass = player.hasPermission("farmxmine.bypass");
+        boolean whitelisted = regionService.isWhitelisted(rt, block.getType());
+        if (!whitelisted) {
+            if (!bypass) {
+                e.setCancelled(true);
+                e.setDropItems(false);
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent("Hier nicht erlaubt"));
+            }
             return;
+        }
+
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        String toolName = hand.getType().name();
+        boolean isHoe = toolName.endsWith("_HOE");
+        boolean isPickaxe = toolName.endsWith("_PICKAXE");
+
+        if (rt == RegionType.FARM) {
+            if (!isHoe || !harvestService.isMatureCrop(block)) {
+                return;
+            }
+        } else if (rt == RegionType.MINE) {
+            if (!isPickaxe) {
+                return;
+            }
         }
 
         e.setDropItems(false);
 
-        ItemStack hand = player.getInventory().getItemInMainHand();
         boolean special = specialApi.isSpecialItem(hand);
         Set<SpecialItemsApi.Effect> effects = special
                 ? new HashSet<>(specialApi.getEffects(hand))
@@ -63,26 +82,30 @@ public class SpecialItemsIntegrationListener implements Listener {
             effects.remove(SpecialItemsApi.Effect.REPLANT);
         }
 
+        int blocksProcessed = 0;
         if (special && effects.contains(SpecialItemsApi.Effect.HARVESTER)) {
             List<Block> targets = harvestService.findAoeTargets(block, rt, Cfg.HARVESTER_MAX_BLOCKS, Cfg.HARVESTER_MAX_RADIUS);
             for (Block t : targets) {
+                if (!regionService.isWhitelisted(rt, t.getType())) continue;
                 if (rt == RegionType.FARM && !harvestService.isMatureCrop(t)) continue;
                 HarvestService.HarvestResult r = harvestService.harvestSingle(player, t, rt, yieldMul);
+                if (rt == RegionType.FARM) filterFarmDrops(t.getType(), r.drops);
                 giveDirectToInventory(player, r.drops);
                 addXp(player, r.xp);
+                blocksProcessed++;
             }
-            e.setCancelled(true);
-            return;
+        } else {
+            HarvestService.HarvestResult r = harvestService.harvestSingle(player, block, rt, yieldMul);
+            if (rt == RegionType.FARM) filterFarmDrops(block.getType(), r.drops);
+            giveDirectToInventory(player, r.drops);
+            addXp(player, r.xp);
+            blocksProcessed = 1;
         }
 
-        if (rt == RegionType.FARM && !harvestService.isMatureCrop(block)) {
-            e.setCancelled(true);
-            return;
+        if (blocksProcessed > 0) {
+            int xp = (rt == RegionType.FARM ? Cfg.XP_FARM : Cfg.XP_MINE) * blocksProcessed;
+            specialApi.grantHarvestXp(player, hand, rt, xp);
         }
-
-        HarvestService.HarvestResult r = harvestService.harvestSingle(player, block, rt, yieldMul);
-        giveDirectToInventory(player, r.drops);
-        addXp(player, r.xp);
         e.setCancelled(true);
     }
 
@@ -97,13 +120,27 @@ public class SpecialItemsIntegrationListener implements Listener {
         for (ItemStack it : drops) {
             leftover.putAll(player.getInventory().addItem(it));
         }
-        for (ItemStack it : leftover.values()) {
-            player.getWorld().dropItemNaturally(player.getLocation(), it);
+        if (!Cfg.VOID_OVERFLOW) {
+            for (ItemStack it : leftover.values()) {
+                player.getWorld().dropItemNaturally(player.getLocation(), it);
+            }
         }
     }
 
     private void addXp(Player player, int xp) {
         player.giveExp(xp);
+    }
+
+    private void filterFarmDrops(org.bukkit.Material blockType, List<ItemStack> drops) {
+        org.bukkit.Material main = switch (blockType) {
+            case WHEAT -> org.bukkit.Material.WHEAT;
+            case BEETROOTS -> org.bukkit.Material.BEETROOT;
+            case CARROTS -> org.bukkit.Material.CARROT;
+            case POTATOES -> org.bukkit.Material.POTATO;
+            default -> null;
+        };
+        if (main == null) return;
+        drops.removeIf(it -> it.getType() != main);
     }
 }
 

--- a/FarmXMine/src/main/java/com/instancednodes/util/Cfg.java
+++ b/FarmXMine/src/main/java/com/instancednodes/util/Cfg.java
@@ -23,13 +23,17 @@ public class Cfg {
 
     public static boolean PLAY_SOUNDS;
     public static boolean REQUIRE_PERMS;
-    public static boolean OVERRIDE_CANCELLED;
+      public static boolean OVERRIDE_CANCELLED;
 
     public static boolean INTEGRATE_SPECIALITEMS;
     public static boolean DISABLE_REPLANT_IN_FARM;
-    public static boolean DIRECT_TO_INVENTORY;
+      public static boolean DIRECT_TO_INVENTORY;
+      public static boolean VOID_OVERFLOW;
     public static int HARVESTER_MAX_BLOCKS;
     public static int HARVESTER_MAX_RADIUS;
+
+    public static int XP_MINE;
+    public static int XP_FARM;
 
     public static String[] VEIN_LORE;
     public static int VEIN_MAX_BLOCKS;
@@ -44,9 +48,13 @@ public class Cfg {
 
         INTEGRATE_SPECIALITEMS = plugin.getConfig().getBoolean("farmxmine.integrate_specialitems", true);
         DISABLE_REPLANT_IN_FARM = plugin.getConfig().getBoolean("farmxmine.disable_replant_in_farm", true);
-        DIRECT_TO_INVENTORY = plugin.getConfig().getBoolean("farmxmine.direct_to_inventory", true);
+          DIRECT_TO_INVENTORY = plugin.getConfig().getBoolean("farmxmine.direct_to_inventory", true);
+          VOID_OVERFLOW = plugin.getConfig().getBoolean("inventory.void_overflow", true);
         HARVESTER_MAX_BLOCKS = plugin.getConfig().getInt("harvester.max_blocks", 32);
         HARVESTER_MAX_RADIUS = plugin.getConfig().getInt("harvester.max_radius", 5);
+
+        XP_MINE = plugin.getConfig().getInt("leveling.xp_per_harvest.mine", 3);
+        XP_FARM = plugin.getConfig().getInt("leveling.xp_per_harvest.farm", 1);
 
         PLAY_SOUNDS = plugin.getConfig().getBoolean("options.play_sounds", false);
         REQUIRE_PERMS = plugin.getConfig().getBoolean("options.require_permissions", false);

--- a/FarmXMine/src/main/resources/config.yml
+++ b/FarmXMine/src/main/resources/config.yml
@@ -10,6 +10,9 @@ farmxmine:
   disable_replant_in_farm: true
   direct_to_inventory: true
 
+inventory:
+  void_overflow: true
+
 harvester:
   max_blocks: 32
   max_radius: 5

--- a/SpecialItems/src/main/java/com/instancednodes/integration/RegionType.java
+++ b/SpecialItems/src/main/java/com/instancednodes/integration/RegionType.java
@@ -1,0 +1,10 @@
+package com.instancednodes.integration;
+
+/**
+ * Types of regions handled by FarmxMine.
+ */
+public enum RegionType {
+    NONE,
+    FARM,
+    MINE
+}

--- a/SpecialItems/src/main/java/com/instancednodes/integration/SpecialItemsApi.java
+++ b/SpecialItems/src/main/java/com/instancednodes/integration/SpecialItemsApi.java
@@ -37,4 +37,3 @@ public interface SpecialItemsApi {
      */
     void grantHarvestXp(Player player, ItemStack item, RegionType regionType, int amount);
 }
-

--- a/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
+++ b/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
@@ -12,6 +12,10 @@ import com.specialitems.util.Configs;
 import com.specialitems.util.Log;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.ServicePriority;
+
+import com.instancednodes.integration.SpecialItemsApi;
+import com.specialitems.integration.SpecialItemsBridge;
 
 // Leveling imports
 import com.specialitems.leveling.LevelingService;
@@ -77,6 +81,7 @@ public class SpecialItemsPlugin extends JavaPlugin {
         // --- Leveling system (NEW) ---
         this.leveling = new LevelingService(this);
         getServer().getPluginManager().registerEvents(new LevelingListener(leveling), this);
+        getServer().getServicesManager().register(SpecialItemsApi.class, new SpecialItemsBridge(leveling), this, ServicePriority.Normal);
 
         // Ticker (kept from your original)
         try {

--- a/SpecialItems/src/main/java/com/specialitems/integration/SpecialItemsBridge.java
+++ b/SpecialItems/src/main/java/com/specialitems/integration/SpecialItemsBridge.java
@@ -1,0 +1,61 @@
+package com.specialitems.integration;
+
+import com.instancednodes.integration.RegionType;
+import com.instancednodes.integration.SpecialItemsApi;
+import com.specialitems.leveling.LevelingService;
+import com.specialitems.leveling.ToolClass;
+import com.specialitems.util.ItemUtil;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public class SpecialItemsBridge implements SpecialItemsApi {
+
+    private final LevelingService leveling;
+
+    public SpecialItemsBridge(LevelingService leveling) {
+        this.leveling = leveling;
+    }
+
+    @Override
+    public boolean isSpecialItem(ItemStack item) {
+        return leveling.isSpecialItem(item);
+    }
+
+    @Override
+    public Set<Effect> getEffects(ItemStack item) {
+        EnumSet<Effect> set = EnumSet.noneOf(Effect.class);
+        if (ItemUtil.getEffectLevel(item, "harvester") > 0 || ItemUtil.getEffectLevel(item, "veinminer") > 0) {
+            set.add(Effect.HARVESTER);
+        }
+        if (ItemUtil.getEffectLevel(item, "replant") > 0) {
+            set.add(Effect.REPLANT);
+        }
+        if (ItemUtil.getToolYieldBonus(item) > 0) {
+            set.add(Effect.YIELD_MULTIPLIER);
+        }
+        return set;
+    }
+
+    @Override
+    public double getYieldMultiplier(ItemStack item) {
+        return 1.0 + ItemUtil.getToolYieldBonus(item);
+    }
+
+    @Override
+    public void grantHarvestXp(Player player, ItemStack item, RegionType regionType, int amount) {
+        ToolClass clazz = regionType == RegionType.MINE ? ToolClass.PICKAXE : ToolClass.HOE;
+        var ups = leveling.grantXp(item, amount, clazz);
+        if (ups == null || ups.isEmpty()) return;
+        String name = (item.hasItemMeta() && item.getItemMeta().hasDisplayName())
+                ? item.getItemMeta().getDisplayName()
+                : item.getType().name();
+        for (var up : ups) {
+            player.sendMessage(ChatColor.AQUA + name + ChatColor.GREEN + " reached level " + ChatColor.YELLOW + up.level()
+                    + (up.enchanted() ? ChatColor.GREEN + " and gained a bonus enchantment!" : ChatColor.GRAY + " without a bonus enchantment."));
+        }
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
@@ -7,6 +7,8 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.ChatColor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,14 +78,25 @@ public final class LevelingService {
     public double getBonusYieldPct(ItemStack it) {
         ItemMeta meta = it.getItemMeta();
         if (meta == null) return 0.0;
-        Double v = meta.getPersistentDataContainer().get(keys.BONUS_YIELD_PCT, PersistentDataType.DOUBLE);
+        String keyName = com.specialitems.util.Configs.cfg.getString("specialitems.yield_bonus_attr_key", "si.yield_bonus");
+        NamespacedKey key = new NamespacedKey(plugin, keyName);
+        Double v = meta.getPersistentDataContainer().get(key, PersistentDataType.DOUBLE);
         return v == null ? 0.0 : v;
     }
 
     public void setBonusYieldPct(ItemStack it, double pct) {
         ItemMeta meta = it.getItemMeta();
         if (meta == null) return;
-        meta.getPersistentDataContainer().set(keys.BONUS_YIELD_PCT, PersistentDataType.DOUBLE, Math.max(0.0, pct));
+        pct = Math.max(0.0, pct);
+        String keyName = com.specialitems.util.Configs.cfg.getString("specialitems.yield_bonus_attr_key", "si.yield_bonus");
+        NamespacedKey key = new NamespacedKey(plugin, keyName);
+        meta.getPersistentDataContainer().set(key, PersistentDataType.DOUBLE, pct);
+
+        List<String> lore = meta.getLore();
+        if (lore == null) lore = new ArrayList<>();
+        com.specialitems.util.ItemUtil.removeLoreLinePrefix(lore, ChatColor.GRAY + "Yield Bonus:");
+        lore.add(ChatColor.GRAY + "Yield Bonus: +" + pct + "%");
+        meta.setLore(lore);
         it.setItemMeta(meta);
     }
 
@@ -129,7 +142,7 @@ public final class LevelingService {
 
             if (success) {
                 switch (clazz) {
-                    case PICKAXE -> EnchantUtil.addOrIncrease(it, Enchantment.EFFICIENCY, 1, allowOverCapPickaxe);
+                    case PICKAXE -> setBonusYieldPct(it, getBonusYieldPct(it) + 10.0);
                     case SWORD   -> EnchantUtil.addOrIncrease(it, Enchantment.SHARPNESS, 1, allowOverCapSword);
                     case HOE     -> setBonusYieldPct(it, getBonusYieldPct(it) + 10.0);
                     case AXE     -> EnchantUtil.addOrIncrease(it, Enchantment.EFFICIENCY, 1, allowOverCapPickaxe);

--- a/SpecialItems/src/main/resources/config.yml
+++ b/SpecialItems/src/main/resources/config.yml
@@ -39,11 +39,15 @@ effects:
   xp_boost: { enabled: true, multiplier-per-level: 0.25 }
 
 specialitems:
-  harvester_scale: 0.25
-  vein_scale: 0.20
+  harvester_scale: 0.35
+  vein_scale: 0.30
+  scaling_mode: "exp"
   min_total_floor: true
   fortune_interaction: "ignore"
   yield_bonus_attr_key: "si.yield_bonus"
 
 farmxmine:
   direct_to_inventory: true
+
+inventory:
+  void_overflow: true


### PR DESCRIPTION
## Summary
- filter farm harvests to main crops and prevent auto-collect on invalid blocks
- restrict mine auto-collect to pickaxes and whitelisted ores, granting tool XP per harvest
- expose SpecialItems service for tool XP and yield bonus; pickaxes now gain and display yield bonuses

## Testing
- `gradle build` in `SpecialItems`
- `gradle build` in `FarmXMine`
- `gradle build` in `LootFactory-src`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4c78dcc8325a42d734fa6efb2e7