### PR TITLE
Add PlaceholderAPI placeholders for FarmXMine

### DIFF
--- a/FarmXMine/build.gradle.kts
+++ b/FarmXMine/build.gradle.kts
@@ -6,10 +6,12 @@ version = "0.4.6"
 repositories {
     mavenCentral()
     maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://repo.extendedclip.com/repository/placeholderapi/")
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("me.clip:placeholderapi:2.11.5")
 }
 
 java {

--- a/FarmXMine/src/main/java/com/instancednodes/InstancedNodesPlugin.java
+++ b/FarmXMine/src/main/java/com/instancednodes/InstancedNodesPlugin.java
@@ -11,6 +11,7 @@ import com.instancednodes.integration.RegionService;
 import com.instancednodes.integration.SpecialItemsApi;
 import com.instancednodes.integration.HarvestService;
 import com.instancednodes.integration.SpecialItemsIntegrationListener;
+import com.instancednodes.placeholder.FarmXMinePlaceholders;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Random;
@@ -45,6 +46,9 @@ public class InstancedNodesPlugin extends JavaPlugin {
         }
         if (getCommand("nodes") != null) getCommand("nodes").setExecutor(new NodesCommand(this));
         if (getCommand("prestige") != null) getCommand("prestige").setExecutor(new PrestigeCommand(this));
+        if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new FarmXMinePlaceholders(this).register();
+        }
         getLogger().info("InstancedNodes enabled v" + getDescription().getVersion());
     }
 

--- a/FarmXMine/src/main/java/com/instancednodes/placeholder/FarmXMinePlaceholders.java
+++ b/FarmXMine/src/main/java/com/instancednodes/placeholder/FarmXMinePlaceholders.java
@@ -1,0 +1,56 @@
+package com.instancednodes.placeholder;
+
+import com.instancednodes.InstancedNodesPlugin;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import java.util.UUID;
+
+/**
+ * PlaceholderAPI expansion for FarmXMine (InstancedNodes).
+ */
+public class FarmXMinePlaceholders extends PlaceholderExpansion {
+
+    private final InstancedNodesPlugin plugin;
+
+    public FarmXMinePlaceholders(InstancedNodesPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "farmxmine";
+    }
+
+    @Override
+    public String getAuthor() {
+        return String.join(", ", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, String params) {
+        if (player == null) {
+            return "";
+        }
+        UUID uid = player.getUniqueId();
+        if (params.equalsIgnoreCase("level")) {
+            return String.valueOf(plugin.level().getLevel(uid));
+        }
+        if (params.equalsIgnoreCase("prestige")) {
+            return String.valueOf(plugin.level().getPrestige(uid));
+        }
+        if (params.equalsIgnoreCase("xp")) {
+            return String.valueOf((int) plugin.data().getXp(uid));
+        }
+        return null;
+    }
+}

--- a/FarmXMine/src/main/resources/messages.yml
+++ b/FarmXMine/src/main/resources/messages.yml
@@ -7,3 +7,8 @@ no_permission: "%prefix%&cYou don't have permission."
 reloaded: "%prefix%&aConfig reloaded."
 debug_on: "%prefix%&aDebug &2ON&a."
 debug_off: "%prefix%&aDebug &cOFF&a."
+
+# PlaceholderAPI placeholders:
+# %farmxmine_level% - Player level
+# %farmxmine_prestige% - Player prestige
+# %farmxmine_xp% - Player XP

--- a/FarmXMine/src/main/resources/plugin.yml
+++ b/FarmXMine/src/main/resources/plugin.yml
@@ -21,4 +21,4 @@ permissions:
     default: true
   instancednodes.prestige:
     default: true
-softdepend: [WorldGuard]
+softdepend: [WorldGuard, PlaceholderAPI]


### PR DESCRIPTION
## Summary
- add `FarmXMinePlaceholders` PlaceholderAPI expansion for level, prestige, and XP
- register expansion on plugin enable and depend on PlaceholderAPI
- document placeholders for server admins

## Testing
- `gradle build` *(fails: Could not resolve me.clip:placeholderapi:2.11.5 – HTTP 403 from repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a59aac6420832595b79e4fb5d8d27c