### PR TITLE
feat: support bonus yield on special pickaxes

### DIFF
--- a/SpecialItems/src/main/resources/config.yml
+++ b/SpecialItems/src/main/resources/config.yml
@@ -99,6 +99,7 @@ leveling:
       xp: "&7XP: &b%XP%&7/&b%NEED%"
       yield_mine: "&7Yield: &a+%YIELD%%% &8(mine)"
       yield_farm: "&7Yield: &a+%YIELD%%% &8(farm)"
+      yield_bonus: "&7Bonus Yield: &a+%YIELD%%%"
   messages:
     level_up: "%ITEM% leveled up to %LEVEL%"
     extra_enchant: "%ITEM% gained %ENCHANT% %LEVEL%"


### PR DESCRIPTION
## Summary
- display bonus yield on special pickaxe lore and include it in total yield
- auto-initialize bonus-yield tools so they level up
- add configurable lore string for bonus yield

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a59afd6c5c8325b98e55a1a478e5a1