### PR TITLE
fix: configure PlaceholderAPI repository and dependency

### DIFF
--- a/FarmXMine/build.gradle.kts
+++ b/FarmXMine/build.gradle.kts
@@ -6,12 +6,12 @@ version = "0.4.6"
 repositories {
     mavenCentral()
     maven("https://repo.papermc.io/repository/maven-public/")
-    maven("https://repo.extendedclip.com/repository/placeholderapi/")
+    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
 }
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
-    compileOnly("me.clip:placeholderapi:2.11.5")
+    compileOnly("me.clip:placeholderapi:2.11.6")
 }
 
 java {
@@ -19,7 +19,7 @@ java {
     withSourcesJar()
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
     options.release.set(21)
 }


### PR DESCRIPTION
## Summary
- point PlaceholderAPI repo to `content/repositories` path
- update compileOnly dependency for PlaceholderAPI 2.11.6
- ensure JavaCompile uses UTF-8 and release 21

## Testing
- `gradle clean build --refresh-dependencies` *(fails: Could not resolve dependencies - HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a59fd117888325a27d4f48ad0b2119