### PR TITLE
Add FocusNPC plugin

### DIFF
--- a/FocusNPC/build.gradle.kts
+++ b/FocusNPC/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins { java }
+
+group = "com.focusnpc"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+    maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
+    maven("https://maven.enginehub.org/repo/")
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("me.clip:placeholderapi:2.11.6")
+}
+
+java {
+    toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
+    withSourcesJar()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    options.release.set(21)
+}
+
+tasks.jar {
+    archiveFileName.set("FocusNPC-${project.version}.jar")
+}

--- a/FocusNPC/settings.gradle.kts
+++ b/FocusNPC/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "FocusNPC"

--- a/FocusNPC/src/main/java/com/focusnpc/FocusNPCPlugin.java
+++ b/FocusNPC/src/main/java/com/focusnpc/FocusNPCPlugin.java
@@ -1,0 +1,80 @@
+package com.focusnpc;
+
+import com.focusnpc.command.FocusNpcCommand;
+import com.focusnpc.data.PlayerData;
+import com.focusnpc.gui.GuiFactory;
+import com.focusnpc.listener.Listeners;
+import com.focusnpc.npc.NpcManager;
+import com.focusnpc.placeholder.FocusPlaceholders;
+import com.focusnpc.transform.BlockTransformer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import me.clip.placeholderapi.PlaceholderAPI;
+
+public class FocusNPCPlugin extends JavaPlugin {
+    private NpcManager npcManager;
+    private PlayerData playerData;
+    private GuiFactory guiFactory;
+    private String farmingPlaceholder;
+    private String miningPlaceholder;
+    private BlockTransformer blockTransformer;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        this.farmingPlaceholder = getConfig().getString("placeholders.farming", "%farmxmine_farming_level%");
+        this.miningPlaceholder = getConfig().getString("placeholders.mining", "%farmxmine_mining_level%");
+        this.playerData = new PlayerData(this);
+        this.npcManager = new NpcManager(this);
+        this.guiFactory = new GuiFactory(this);
+        this.blockTransformer = new BlockTransformer(this);
+        this.blockTransformer.reload();
+
+        FocusNpcCommand cmd = new FocusNpcCommand(this);
+        getCommand("focusnpc").setExecutor(cmd);
+        getCommand("focusnpc").setTabCompleter(cmd);
+
+        Bukkit.getPluginManager().registerEvents(new Listeners(this), this);
+
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new FocusPlaceholders(this).register();
+        }
+
+        npcManager.load();
+    }
+
+    public void reload() {
+        reloadConfig();
+        this.farmingPlaceholder = getConfig().getString("placeholders.farming", "%farmxmine_farming_level%");
+        this.miningPlaceholder = getConfig().getString("placeholders.mining", "%farmxmine_mining_level%");
+        this.playerData.reload();
+        this.npcManager.reload();
+        this.blockTransformer.reload();
+    }
+
+    public PlayerData getPlayerData() { return playerData; }
+    public GuiFactory getGuiFactory() { return guiFactory; }
+    public NpcManager getNpcManager() { return npcManager; }
+    public BlockTransformer getBlockTransformer() { return blockTransformer; }
+
+    public int getFarmingLevel(Player player) {
+        return getLevel(player, farmingPlaceholder);
+    }
+
+    public int getMiningLevel(Player player) {
+        return getLevel(player, miningPlaceholder);
+    }
+
+    private int getLevel(Player player, String placeholder) {
+        if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            return 0;
+        }
+        String value = PlaceholderAPI.setPlaceholders(player, placeholder);
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/command/FocusNpcCommand.java
+++ b/FocusNPC/src/main/java/com/focusnpc/command/FocusNpcCommand.java
@@ -1,0 +1,97 @@
+package com.focusnpc.command;
+
+import com.focusnpc.FocusNPCPlugin;
+import com.focusnpc.npc.FocusNpc;
+import com.focusnpc.npc.NpcManager;
+import com.focusnpc.npc.NpcType;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FocusNpcCommand implements CommandExecutor, TabCompleter {
+    private final FocusNPCPlugin plugin;
+
+    public FocusNpcCommand(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+        if (!player.hasPermission("focusnpc.admin")) {
+            player.sendMessage("§cNo permission.");
+            return true;
+        }
+        if (args.length == 0) {
+            player.sendMessage("§eUse /focusnpc <spawn|remove|list|reload>");
+            return true;
+        }
+        NpcManager manager = plugin.getNpcManager();
+        switch (args[0].toLowerCase()) {
+            case "spawn":
+                if (args.length < 2) {
+                    player.sendMessage("§cSpecify type: farmer or miner");
+                    return true;
+                }
+                NpcType type;
+                try { type = NpcType.valueOf(args[1].toUpperCase()); }
+                catch (IllegalArgumentException ex) {
+                    player.sendMessage("§cUnknown type.");
+                    return true;
+                }
+                String skin = plugin.getConfig().getString("npcs." + args[1].toLowerCase() + ".skin", "");
+                Location loc = player.getLocation();
+                manager.spawnNpc(type, loc, skin);
+                manager.save();
+                player.sendMessage("§aSpawned " + type.name().toLowerCase() + " NPC.");
+                break;
+            case "remove":
+                if (manager.removeNearest(player.getLocation())) {
+                    player.sendMessage("§aRemoved nearest NPC.");
+                } else {
+                    player.sendMessage("§cNo NPC found nearby.");
+                }
+                break;
+            case "list":
+                List<FocusNpc> list = manager.getNpcs();
+                if (list.isEmpty()) {
+                    player.sendMessage("§7No NPCs.");
+                } else {
+                    int i = 1;
+                    for (FocusNpc npc : list) {
+                        Location l = npc.getLocation();
+                        player.sendMessage(i++ + ". " + npc.getType() + " - " + l.getWorld().getName() + " " + l.getBlockX() + " " + l.getBlockY() + " " + l.getBlockZ());
+                    }
+                }
+                break;
+            case "reload":
+                plugin.reload();
+                player.sendMessage("§aFocusNPC reloaded.");
+                break;
+            default:
+                player.sendMessage("§eUse /focusnpc <spawn|remove|list|reload>");
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return Arrays.asList("spawn", "remove", "list", "reload");
+        }
+        if (args.length == 2 && args[0].equalsIgnoreCase("spawn")) {
+            return Arrays.asList("farmer", "miner");
+        }
+        return new ArrayList<>();
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/data/PlayerData.java
+++ b/FocusNPC/src/main/java/com/focusnpc/data/PlayerData.java
@@ -1,0 +1,60 @@
+package com.focusnpc.data;
+
+import com.focusnpc.FocusNPCPlugin;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+public class PlayerData {
+    private final FocusNPCPlugin plugin;
+    private final File file;
+    private FileConfiguration config;
+
+    public PlayerData(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "players.yml");
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            try { file.createNewFile(); } catch (IOException ignored) {}
+        }
+        this.config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public void reload() {
+        this.config = YamlConfiguration.loadConfiguration(file);
+    }
+
+    public Material getFarmFocus(UUID uuid) {
+        String path = uuid.toString() + ".farm_focus";
+        String name = config.getString(path, "WHEAT");
+        Material mat = Material.matchMaterial(name);
+        return mat != null ? mat : Material.WHEAT;
+    }
+
+    public void setFarmFocus(UUID uuid, Material mat) {
+        config.set(uuid.toString() + ".farm_focus", mat.name());
+        save();
+    }
+
+    public Material getMineFocus(UUID uuid) {
+        String path = uuid.toString() + ".mine_focus";
+        String name = config.getString(path, "COAL_ORE");
+        Material mat = Material.matchMaterial(name);
+        return mat != null ? mat : Material.COAL_ORE;
+    }
+
+    public void setMineFocus(UUID uuid, Material mat) {
+        config.set(uuid.toString() + ".mine_focus", mat.name());
+        save();
+    }
+
+    private void save() {
+        try {
+            config.save(file);
+        } catch (IOException ignored) {}
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/gui/GuiFactory.java
+++ b/FocusNPC/src/main/java/com/focusnpc/gui/GuiFactory.java
@@ -1,0 +1,81 @@
+package com.focusnpc.gui;
+
+import com.focusnpc.FocusNPCPlugin;
+import com.focusnpc.npc.NpcType;
+import com.focusnpc.util.TextUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.*;
+
+public class GuiFactory {
+    public static final Map<Material, Integer> FARMER_OPTIONS = Map.of(
+            Material.WHEAT, 0,
+            Material.CARROT, 100,
+            Material.POTATO, 200,
+            Material.NETHER_WART, 300
+    );
+
+    public static final Map<Material, Integer> MINER_OPTIONS = Map.ofEntries(
+            Map.entry(Material.COAL_ORE, 0),
+            Map.entry(Material.IRON_ORE, 100),
+            Map.entry(Material.COPPER_ORE, 150),
+            Map.entry(Material.REDSTONE_ORE, 200),
+            Map.entry(Material.LAPIS_ORE, 220),
+            Map.entry(Material.GOLD_ORE, 250),
+            Map.entry(Material.DIAMOND_ORE, 300),
+            Map.entry(Material.EMERALD_ORE, 350),
+            Map.entry(Material.NETHER_QUARTZ_ORE, 120),
+            Map.entry(Material.ANCIENT_DEBRIS, 400)
+    );
+
+    private final FocusNPCPlugin plugin;
+
+    public GuiFactory(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openGui(Player player, NpcType type) {
+        player.openInventory(buildGui(player, type));
+    }
+
+    private Inventory buildGui(Player player, NpcType type) {
+        Inventory inv = Bukkit.createInventory(new GuiHolder(type), 9, type == NpcType.FARMER ? "Farmer Focus" : "Miner Focus");
+        Map<Material, Integer> options = type == NpcType.FARMER ? FARMER_OPTIONS : MINER_OPTIONS;
+        Material current = type == NpcType.FARMER ? plugin.getPlayerData().getFarmFocus(player.getUniqueId()) : plugin.getPlayerData().getMineFocus(player.getUniqueId());
+        int level = type == NpcType.FARMER ? plugin.getFarmingLevel(player) : plugin.getMiningLevel(player);
+        for (Map.Entry<Material, Integer> e : options.entrySet()) {
+            Material mat = e.getKey();
+            int required = e.getValue();
+            ItemStack item = new ItemStack(mat);
+            ItemMeta meta = item.getItemMeta();
+            meta.setDisplayName(ChatColor.YELLOW + TextUtil.format(mat));
+            List<String> lore = new ArrayList<>();
+            if (mat == current) {
+                lore.add("§7Current Focus");
+            } else if (level >= required) {
+                lore.add("§aClick to select");
+            } else {
+                lore.add("§cLocked — Requires " + (type == NpcType.FARMER ? "Farming" : "Mining") + " Level " + required);
+            }
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+            inv.addItem(item);
+        }
+        return inv;
+    }
+
+    public static class GuiHolder implements InventoryHolder {
+        private final NpcType type;
+        public GuiHolder(NpcType type) { this.type = type; }
+        public NpcType getType() { return type; }
+        @Override
+        public Inventory getInventory() { return null; }
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/listener/Listeners.java
+++ b/FocusNPC/src/main/java/com/focusnpc/listener/Listeners.java
@@ -1,0 +1,70 @@
+package com.focusnpc.listener;
+
+import com.focusnpc.FocusNPCPlugin;
+import com.focusnpc.gui.GuiFactory;
+import com.focusnpc.npc.FocusNpc;
+import com.focusnpc.npc.NpcType;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+
+public class Listeners implements Listener {
+    private final FocusNPCPlugin plugin;
+
+    public Listeners(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onEntityClick(PlayerInteractAtEntityEvent event) {
+        Entity entity = event.getRightClicked();
+        FocusNpc npc = plugin.getNpcManager().getByEntityId(entity.getUniqueId());
+        if (npc != null) {
+            event.setCancelled(true);
+            plugin.getGuiFactory().openGui(event.getPlayer(), npc.getType());
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getInventory().getHolder() instanceof GuiFactory.GuiHolder holder)) return;
+        event.setCancelled(true);
+        ItemStack item = event.getCurrentItem();
+        if (item == null || item.getType() == Material.AIR) return;
+        Material mat = item.getType();
+        Player player = (Player) event.getWhoClicked();
+        NpcType type = holder.getType();
+        Map<Material, Integer> options = type == NpcType.FARMER ? GuiFactory.FARMER_OPTIONS : GuiFactory.MINER_OPTIONS;
+        int level = type == NpcType.FARMER ? plugin.getFarmingLevel(player) : plugin.getMiningLevel(player);
+        int required = options.getOrDefault(mat, Integer.MAX_VALUE);
+        if (level < required) {
+            player.sendMessage("§cLocked — Requires " + (type == NpcType.FARMER ? "Farming" : "Mining") + " Level " + required);
+            return;
+        }
+        if (type == NpcType.FARMER) {
+            if (plugin.getPlayerData().getFarmFocus(player.getUniqueId()) == mat) {
+                player.sendMessage("§7Already selected.");
+            } else {
+                plugin.getPlayerData().setFarmFocus(player.getUniqueId(), mat);
+                player.sendMessage("§aFarm focus set to " + mat.name());
+                plugin.getBlockTransformer().transform(player, NpcType.FARMER, mat);
+            }
+        } else {
+            if (plugin.getPlayerData().getMineFocus(player.getUniqueId()) == mat) {
+                player.sendMessage("§7Already selected.");
+            } else {
+                plugin.getPlayerData().setMineFocus(player.getUniqueId(), mat);
+                player.sendMessage("§aMine focus set to " + mat.name());
+                plugin.getBlockTransformer().transform(player, NpcType.MINER, mat);
+            }
+        }
+        player.closeInventory();
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/npc/FocusNpc.java
+++ b/FocusNPC/src/main/java/com/focusnpc/npc/FocusNpc.java
@@ -1,0 +1,30 @@
+package com.focusnpc.npc;
+
+import org.bukkit.Location;
+
+import java.util.UUID;
+
+public class FocusNpc {
+    private final NpcType type;
+    private final Location location;
+    private final String skin;
+    private Object citizen;
+    private Integer citizenId;
+    private UUID entityId;
+
+    public FocusNpc(NpcType type, Location location, String skin) {
+        this.type = type;
+        this.location = location;
+        this.skin = skin;
+    }
+
+    public NpcType getType() { return type; }
+    public Location getLocation() { return location; }
+    public String getSkin() { return skin; }
+    public Object getCitizen() { return citizen; }
+    public void setCitizen(Object citizen) { this.citizen = citizen; }
+    public Integer getCitizenId() { return citizenId; }
+    public void setCitizenId(Integer citizenId) { this.citizenId = citizenId; }
+    public UUID getEntityId() { return entityId; }
+    public void setEntityId(UUID entityId) { this.entityId = entityId; }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/npc/NpcManager.java
+++ b/FocusNPC/src/main/java/com/focusnpc/npc/NpcManager.java
@@ -1,0 +1,214 @@
+package com.focusnpc.npc;
+
+import com.focusnpc.FocusNPCPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Event;
+import org.bukkit.event.EventException;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.EventExecutor;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+public class NpcManager {
+    private final FocusNPCPlugin plugin;
+    private final boolean citizens;
+    private Object npcRegistry;
+    private Method createNpc;
+    private Method spawn;
+    private Method getId;
+    private Method destroy;
+    private Method getById;
+    private Method getOrAddTrait;
+    private Method getEntity;
+    private Class<?> skinTraitClass;
+    private Method setSkinName;
+    private final List<FocusNpc> npcs = new ArrayList<>();
+
+    public NpcManager(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+        this.citizens = Bukkit.getPluginManager().isPluginEnabled("Citizens");
+        if (citizens) {
+            try {
+                Class<?> api = Class.forName("net.citizensnpcs.api.CitizensAPI");
+                npcRegistry = api.getMethod("getNPCRegistry").invoke(null);
+                createNpc = npcRegistry.getClass().getMethod("createNPC", EntityType.class, String.class);
+                Class<?> npcClass = Class.forName("net.citizensnpcs.api.npc.NPC");
+                spawn = npcClass.getMethod("spawn", Location.class);
+                getId = npcClass.getMethod("getId");
+                destroy = npcClass.getMethod("destroy");
+                getById = npcRegistry.getClass().getMethod("getById", int.class);
+                getOrAddTrait = npcClass.getMethod("getOrAddTrait", Class.class);
+                getEntity = npcClass.getMethod("getEntity");
+                skinTraitClass = Class.forName("net.citizensnpcs.api.trait.trait.SkinTrait");
+                setSkinName = skinTraitClass.getMethod("setSkinName", String.class);
+
+                // register click event via reflection
+                Class<? extends Event> eventClass = (Class<? extends Event>) Class.forName("net.citizensnpcs.api.event.NPCRightClickEvent");
+                Bukkit.getPluginManager().registerEvent(eventClass, new Listener() {}, EventPriority.NORMAL, new EventExecutor() {
+                    @Override
+                    public void execute(Listener listener, Event event) throws EventException {
+                        try {
+                            Object npc = eventClass.getMethod("getNPC").invoke(event);
+                            int id = (int) getId.invoke(npc);
+                            Object player = eventClass.getMethod("getClicker").invoke(event);
+                            if (player instanceof org.bukkit.entity.Player p) {
+                                FocusNpc fn = getByCitizenId(id);
+                                if (fn != null) {
+                                    plugin.getGuiFactory().openGui(p, fn.getType());
+                                }
+                            }
+                        } catch (Exception ignored) {}
+                    }
+                }, plugin);
+            } catch (Exception e) {
+                // disable citizens features on failure
+            }
+        }
+    }
+
+    public void load() {
+        npcs.clear();
+        List<Map<?, ?>> list = plugin.getConfig().getMapList("npcs.saved");
+        for (Map<?, ?> map : list) {
+            try {
+                NpcType type = NpcType.valueOf((String) map.get("type"));
+                World world = Bukkit.getWorld((String) map.get("world"));
+                if (world == null) continue;
+                double x = ((Number) map.get("x")).doubleValue();
+                double y = ((Number) map.get("y")).doubleValue();
+                double z = ((Number) map.get("z")).doubleValue();
+                float yaw = ((Number) (map.containsKey("yaw") ? map.get("yaw") : 0D)).floatValue();
+                float pitch = ((Number) (map.containsKey("pitch") ? map.get("pitch") : 0D)).floatValue();
+                String skin = (String) map.get("skin");
+                Location loc = new Location(world, x, y, z, yaw, pitch);
+                spawnNpc(type, loc, skin);
+            } catch (Exception ignored) {}
+        }
+    }
+
+    public void reload() {
+        despawnAll();
+        load();
+    }
+
+    public FocusNpc spawnNpc(NpcType type, Location loc, String skin) {
+        FocusNpc fnpc = new FocusNpc(type, loc, skin);
+        if (citizens && npcRegistry != null) {
+            try {
+                Object npc = createNpc.invoke(npcRegistry, EntityType.PLAYER, getName(type));
+                spawn.invoke(npc, loc);
+                Object trait = getOrAddTrait.invoke(npc, skinTraitClass);
+                if (skin != null && !skin.isEmpty()) {
+                    setSkinName.invoke(trait, skin);
+                }
+                Object entity = getEntity.invoke(npc);
+                if (entity instanceof LivingEntity le) {
+                    le.setSilent(true);
+                }
+                int id = (int) getId.invoke(npc);
+                fnpc.setCitizen(npc);
+                fnpc.setCitizenId(id);
+            } catch (Exception ignored) {
+            }
+        } else {
+            ArmorStand as = (ArmorStand) loc.getWorld().spawnEntity(loc, EntityType.ARMOR_STAND);
+            as.setCustomName(getName(type));
+            as.setCustomNameVisible(true);
+            as.setGravity(false);
+            as.setSilent(true);
+            fnpc.setEntityId(as.getUniqueId());
+        }
+        npcs.add(fnpc);
+        return fnpc;
+    }
+
+    public void despawnAll() {
+        for (FocusNpc npc : npcs) {
+            if (citizens && npc.getCitizen() != null) {
+                try { destroy.invoke(npc.getCitizen()); } catch (Exception ignored) {}
+            } else if (npc.getEntityId() != null) {
+                Entity ent = Bukkit.getEntity(npc.getEntityId());
+                if (ent != null) ent.remove();
+            }
+        }
+        npcs.clear();
+    }
+
+    public boolean removeNearest(Location loc) {
+        FocusNpc nearest = getNearest(loc);
+        if (nearest == null) return false;
+        if (citizens && nearest.getCitizen() != null) {
+            try { destroy.invoke(nearest.getCitizen()); } catch (Exception ignored) {}
+        } else if (nearest.getEntityId() != null) {
+            Entity ent = Bukkit.getEntity(nearest.getEntityId());
+            if (ent != null) ent.remove();
+        }
+        npcs.remove(nearest);
+        save();
+        return true;
+    }
+
+    private FocusNpc getNearest(Location loc) {
+        FocusNpc best = null;
+        double dist = Double.MAX_VALUE;
+        for (FocusNpc n : npcs) {
+            Location l = n.getLocation();
+            if (!l.getWorld().equals(loc.getWorld())) continue;
+            double d = l.distanceSquared(loc);
+            if (d < dist) {
+                dist = d;
+                best = n;
+            }
+        }
+        if (dist > 25) return null;
+        return best;
+    }
+
+    public FocusNpc getByCitizenId(int id) {
+        for (FocusNpc n : npcs) {
+            if (n.getCitizenId() != null && n.getCitizenId() == id) return n;
+        }
+        return null;
+    }
+
+    public FocusNpc getByEntityId(UUID id) {
+        for (FocusNpc n : npcs) {
+            if (id.equals(n.getEntityId())) return n;
+        }
+        return null;
+    }
+
+    public List<FocusNpc> getNpcs() { return Collections.unmodifiableList(npcs); }
+
+    public void save() {
+        List<Map<String, Object>> list = new ArrayList<>();
+        for (FocusNpc n : npcs) {
+            Location l = n.getLocation();
+            Map<String, Object> map = new HashMap<>();
+            map.put("type", n.getType().name());
+            map.put("world", l.getWorld().getName());
+            map.put("x", l.getX());
+            map.put("y", l.getY());
+            map.put("z", l.getZ());
+            map.put("yaw", l.getYaw());
+            map.put("pitch", l.getPitch());
+            map.put("skin", n.getSkin());
+            list.add(map);
+        }
+        plugin.getConfig().set("npcs.saved", list);
+        plugin.saveConfig();
+    }
+
+    private String getName(NpcType type) {
+        return type == NpcType.FARMER ? ChatColor.GREEN + "Farmer" : ChatColor.AQUA + "Miner";
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/npc/NpcType.java
+++ b/FocusNPC/src/main/java/com/focusnpc/npc/NpcType.java
@@ -1,0 +1,6 @@
+package com.focusnpc.npc;
+
+public enum NpcType {
+    FARMER,
+    MINER
+}

--- a/FocusNPC/src/main/java/com/focusnpc/placeholder/FocusPlaceholders.java
+++ b/FocusNPC/src/main/java/com/focusnpc/placeholder/FocusPlaceholders.java
@@ -1,0 +1,44 @@
+package com.focusnpc.placeholder;
+
+import com.focusnpc.FocusNPCPlugin;
+import com.focusnpc.util.TextUtil;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Material;
+
+public class FocusPlaceholders extends PlaceholderExpansion {
+    private final FocusNPCPlugin plugin;
+
+    public FocusPlaceholders(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "focusnpc";
+    }
+
+    @Override
+    public String getAuthor() {
+        return "FocusNPC";
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, String params) {
+        if (player == null) return "";
+        if (params.equalsIgnoreCase("farm_target")) {
+            Material mat = plugin.getPlayerData().getFarmFocus(player.getUniqueId());
+            return TextUtil.format(mat);
+        }
+        if (params.equalsIgnoreCase("mine_target")) {
+            Material mat = plugin.getPlayerData().getMineFocus(player.getUniqueId());
+            return TextUtil.format(mat);
+        }
+        return null;
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/transform/BlockTransformer.java
+++ b/FocusNPC/src/main/java/com/focusnpc/transform/BlockTransformer.java
@@ -1,0 +1,194 @@
+package com.focusnpc.transform;
+
+import com.focusnpc.FocusNPCPlugin;
+import com.focusnpc.npc.NpcType;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.Bukkit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.*;
+
+public class BlockTransformer {
+    private final FocusNPCPlugin plugin;
+    private int radius;
+    private int maxPerTick;
+    private boolean respectWorldGuard;
+    private Set<String> allowedWorlds = new HashSet<>();
+
+    // WorldGuard reflection
+    private boolean wgAvailable = false;
+    private Object wgPlugin;
+    private Object regionContainer;
+    private Method wrapPlayer;
+    private Method createQuery;
+    private Method adaptLocation;
+    private Method testState;
+    private Object buildFlag;
+
+    private static final Set<Material> CROP_TYPES = EnumSet.of(
+            Material.WHEAT,
+            Material.CARROTS,
+            Material.POTATOES,
+            Material.BEETROOTS,
+            Material.NETHER_WART
+    );
+
+    private static final Set<Material> ORE_TYPES = EnumSet.of(
+            Material.COAL_ORE,
+            Material.DEEPSLATE_COAL_ORE,
+            Material.IRON_ORE,
+            Material.DEEPSLATE_IRON_ORE,
+            Material.COPPER_ORE,
+            Material.DEEPSLATE_COPPER_ORE,
+            Material.GOLD_ORE,
+            Material.DEEPSLATE_GOLD_ORE,
+            Material.REDSTONE_ORE,
+            Material.DEEPSLATE_REDSTONE_ORE,
+            Material.LAPIS_ORE,
+            Material.DEEPSLATE_LAPIS_ORE,
+            Material.DIAMOND_ORE,
+            Material.DEEPSLATE_DIAMOND_ORE,
+            Material.EMERALD_ORE,
+            Material.DEEPSLATE_EMERALD_ORE,
+            Material.NETHER_QUARTZ_ORE,
+            Material.NETHER_GOLD_ORE,
+            Material.ANCIENT_DEBRIS
+    );
+
+    public BlockTransformer(FocusNPCPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void reload() {
+        this.radius = plugin.getConfig().getInt("transform.radius", 100);
+        this.maxPerTick = plugin.getConfig().getInt("transform.max_blocks_per_tick", 500);
+        this.respectWorldGuard = plugin.getConfig().getBoolean("transform.respect_worldguard", true);
+        this.allowedWorlds = new HashSet<>(plugin.getConfig().getStringList("transform.allowed_worlds"));
+        setupWorldGuard();
+    }
+
+    private void setupWorldGuard() {
+        wgAvailable = false;
+        if (!respectWorldGuard || !Bukkit.getPluginManager().isPluginEnabled("WorldGuard")) return;
+        try {
+            wgPlugin = Bukkit.getPluginManager().getPlugin("WorldGuard");
+            Class<?> wgPluginClass = Class.forName("com.sk89q.worldguard.bukkit.WorldGuardPlugin");
+            wrapPlayer = wgPluginClass.getMethod("wrapPlayer", Player.class);
+
+            Class<?> wgClass = Class.forName("com.sk89q.worldguard.WorldGuard");
+            Object wg = wgClass.getMethod("getInstance").invoke(null);
+            Object platform = wgClass.getMethod("getPlatform").invoke(wg);
+            regionContainer = platform.getClass().getMethod("getRegionContainer").invoke(platform);
+
+            Class<?> containerClass = Class.forName("com.sk89q.worldguard.protection.regions.RegionContainer");
+            createQuery = containerClass.getMethod("createQuery");
+            Class<?> queryClass = Class.forName("com.sk89q.worldguard.protection.regions.RegionQuery");
+            Class<?> weLoc = Class.forName("com.sk89q.worldedit.util.Location");
+            Class<?> localPlayer = Class.forName("com.sk89q.worldguard.LocalPlayer");
+            Class<?> stateFlag = Class.forName("com.sk89q.worldguard.protection.flags.StateFlag");
+            testState = queryClass.getMethod("testState", weLoc, localPlayer, stateFlag);
+
+            Class<?> adapterClass = Class.forName("com.sk89q.worldedit.bukkit.BukkitAdapter");
+            adaptLocation = adapterClass.getMethod("adapt", Location.class);
+            Class<?> flagsClass = Class.forName("com.sk89q.worldguard.protection.flags.Flags");
+            Field build = flagsClass.getField("BUILD");
+            buildFlag = build.get(null);
+            wgAvailable = true;
+        } catch (Exception ignored) {
+            wgAvailable = false;
+        }
+    }
+
+    public void transform(Player player, NpcType type, Material target) {
+        World world = player.getWorld();
+        if (!allowedWorlds.isEmpty() && !allowedWorlds.contains(world.getName())) {
+            return;
+        }
+        Location loc = player.getLocation();
+        int cx = loc.getBlockX();
+        int cy = loc.getBlockY();
+        int cz = loc.getBlockZ();
+        int radiusSq = radius * radius;
+        List<Block> blocks = new ArrayList<>();
+        for (int x = cx - radius; x <= cx + radius; x++) {
+            for (int y = cy - radius; y <= cy + radius; y++) {
+                for (int z = cz - radius; z <= cz + radius; z++) {
+                    int dx = x - cx;
+                    int dy = y - cy;
+                    int dz = z - cz;
+                    if (dx*dx + dy*dy + dz*dz > radiusSq) continue;
+                    if (!world.isChunkLoaded(x >> 4, z >> 4)) continue;
+                    Block block = world.getBlockAt(x, y, z);
+                    if (type == NpcType.FARMER) {
+                        if (isMatureCrop(block)) {
+                            blocks.add(block);
+                        }
+                    } else {
+                        if (ORE_TYPES.contains(block.getType())) {
+                            blocks.add(block);
+                        }
+                    }
+                }
+            }
+        }
+        if (blocks.isEmpty()) {
+            player.sendMessage("§eNo blocks to transform.");
+            return;
+        }
+        new BukkitRunnable() {
+            int index = 0;
+            int changed = 0;
+            @Override
+            public void run() {
+                int processed = 0;
+                while (index < blocks.size() && processed < maxPerTick) {
+                    Block b = blocks.get(index++);
+                    if (!canModify(player, b)) continue;
+                    if (type == NpcType.FARMER) {
+                        b.setType(target);
+                        BlockData data = b.getBlockData();
+                        if (data instanceof Ageable age) {
+                            age.setAge(age.getMaximumAge());
+                            b.setBlockData(age);
+                        }
+                    } else {
+                        b.setType(target);
+                    }
+                    changed++;
+                    processed++;
+                }
+                if (index >= blocks.size()) {
+                    player.sendMessage("§aReplaced " + changed + " blocks.");
+                    cancel();
+                }
+            }
+        }.runTaskTimer(plugin, 1L, 1L);
+    }
+
+    private boolean canModify(Player player, Block block) {
+        if (!respectWorldGuard || !wgAvailable) return true;
+        try {
+            Object query = createQuery.invoke(regionContainer);
+            Object localPlayer = wrapPlayer.invoke(wgPlugin, player);
+            Object loc = adaptLocation.invoke(null, block.getLocation());
+            return (boolean) testState.invoke(query, loc, localPlayer, buildFlag);
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    private boolean isMatureCrop(Block block) {
+        if (!CROP_TYPES.contains(block.getType())) return false;
+        BlockData data = block.getBlockData();
+        if (data instanceof Ageable age) {
+            return age.getAge() == age.getMaximumAge();
+        }
+        return false;
+    }
+}

--- a/FocusNPC/src/main/java/com/focusnpc/util/TextUtil.java
+++ b/FocusNPC/src/main/java/com/focusnpc/util/TextUtil.java
@@ -1,0 +1,16 @@
+package com.focusnpc.util;
+
+import org.bukkit.Material;
+
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TextUtil {
+    public static String format(Material mat) {
+        String name = mat.name().toLowerCase(Locale.ROOT).replace('_', ' ');
+        return Stream.of(name.split(" "))
+                .map(s -> s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1))
+                .collect(Collectors.joining(" "));
+    }
+}

--- a/FocusNPC/src/main/resources/config.yml
+++ b/FocusNPC/src/main/resources/config.yml
@@ -1,0 +1,16 @@
+placeholders:
+  farming: "%farmxmine_farming_level%"
+  mining: "%farmxmine_mining_level%"
+
+npcs:
+  farmer:
+    skin: "FarmerSkinName"
+  miner:
+    skin: "MinerSkinName"
+  saved: []
+
+transform:
+  radius: 100
+  max_blocks_per_tick: 500
+  respect_worldguard: true
+  allowed_worlds: [ "world" ]

--- a/FocusNPC/src/main/resources/plugin.yml
+++ b/FocusNPC/src/main/resources/plugin.yml
@@ -1,0 +1,14 @@
+name: FocusNPC
+main: com.focusnpc.FocusNPCPlugin
+version: 1.0.0
+api-version: "1.21"
+softdepend: [PlaceholderAPI, Citizens, FarmXMine, WorldGuard]
+commands:
+  focusnpc:
+    description: Manage FocusNPCs
+    usage: /focusnpc <spawn|remove|list|reload>
+    permission: focusnpc.admin
+permissions:
+  focusnpc.admin:
+    description: Allows managing FocusNPCs
+    default: op


### PR DESCRIPTION
## Summary
- spawn skinned, silent NPCs via Citizens with ArmorStand fallback
- transform nearby crops or ores after focus selection with optional WorldGuard checks
- add configurable transformation settings and WorldGuard soft-dependency

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc0110c4832589d737a219d750b1