### PR TITLE
Fix instancing and leveling in FarmxMine

### DIFF
--- a/FarmXMine/src/main/java/com/farmxmine/service/BossbarService.java
+++ b/FarmXMine/src/main/java/com/farmxmine/service/BossbarService.java
@@ -15,15 +15,13 @@ public class BossbarService {
     private final Map<UUID, BossInfo> bars = new HashMap<>();
     private final BossBar.Color color;
     private final BossBar.Overlay style;
-    private final int idleTimeout;
-    private final int activeTimeout;
+    private final int timeout;
     private final String titleMining;
     private final String titleFarming;
 
     private static class BossInfo {
         BossBar bar;
-        int idleTask;
-        int hardTask;
+        int task;
     }
 
     public boolean isActive(Player player) {
@@ -35,8 +33,7 @@ public class BossbarService {
         this.plugin = plugin;
         this.color = BossBar.Color.valueOf(plugin.getConfig().getString("bossbar.color", "BLUE"));
         this.style = BossBar.Overlay.valueOf(plugin.getConfig().getString("bossbar.style", "SOLID"));
-        this.idleTimeout = plugin.getConfig().getInt("bossbar.timeout_idle_seconds", 10);
-        this.activeTimeout = plugin.getConfig().getInt("bossbar.timeout_active_seconds", 30);
+        this.timeout = plugin.getConfig().getInt("bossbar.timeout_active_seconds", 30);
         this.titleMining = plugin.getConfig().getString("bossbar.title_mining", "Mining");
         this.titleFarming = plugin.getConfig().getString("bossbar.title_farming", "Farming");
     }
@@ -52,10 +49,8 @@ public class BossbarService {
         String title = mining ? titleMining : titleFarming;
         info.bar.name(net.kyori.adventure.text.Component.text(title + " L" + level + " " + (int)xp + "/" + (int)next));
         info.bar.progress((float) (xp / next));
-        if (info.idleTask != 0) Bukkit.getScheduler().cancelTask(info.idleTask);
-        if (info.hardTask != 0) Bukkit.getScheduler().cancelTask(info.hardTask);
-        info.idleTask = Bukkit.getScheduler().runTaskLater(plugin, () -> hide(player), idleTimeout * 20L).getTaskId();
-        info.hardTask = Bukkit.getScheduler().runTaskLater(plugin, () -> hide(player), activeTimeout * 20L).getTaskId();
+        if (info.task != 0) Bukkit.getScheduler().cancelTask(info.task);
+        info.task = Bukkit.getScheduler().runTaskLater(plugin, () -> hide(player), timeout * 20L).getTaskId();
     }
 
     public void hide(Player player) {

--- a/FarmXMine/src/main/java/com/farmxmine/service/LevelService.java
+++ b/FarmXMine/src/main/java/com/farmxmine/service/LevelService.java
@@ -1,6 +1,7 @@
 package com.farmxmine.service;
 
 import com.farmxmine.data.PlayerData;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -42,7 +43,11 @@ public class LevelService {
             levelled = true;
         }
         bossbars.update(player, true, data.getMiningXp(), nextReq(data.getMiningLevel()), data.getMiningLevel());
-        if (levelled) artifacts.tryGrant(player, ArtifactService.Category.MINING);
+        if (levelled) {
+            player.sendMessage("Mining level up! Now level " + data.getMiningLevel());
+            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
+            artifacts.tryGrant(player, ArtifactService.Category.MINING);
+        }
     }
 
     public void addFarmXp(Player player, int count) {
@@ -56,6 +61,10 @@ public class LevelService {
             levelled = true;
         }
         bossbars.update(player, false, data.getFarmingXp(), nextReq(data.getFarmingLevel()), data.getFarmingLevel());
-        if (levelled) artifacts.tryGrant(player, ArtifactService.Category.FARMING);
+        if (levelled) {
+            player.sendMessage("Farming level up! Now level " + data.getFarmingLevel());
+            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1f, 1f);
+            artifacts.tryGrant(player, ArtifactService.Category.FARMING);
+        }
     }
 }

--- a/FarmXMine/src/main/resources/config.yml
+++ b/FarmXMine/src/main/resources/config.yml
@@ -2,8 +2,33 @@ general:
   debug: false
   disabled-worlds: []
   max-broken-blocks: 64
- 
-respawn_seconds: 30
+override_cancelled: false
+ores:
+  - COAL_ORE
+  - COPPER_ORE
+  - IRON_ORE
+  - GOLD_ORE
+  - REDSTONE_ORE
+  - LAPIS_ORE
+  - DIAMOND_ORE
+  - EMERALD_ORE
+  - DEEPSLATE_COAL_ORE
+  - DEEPSLATE_COPPER_ORE
+  - DEEPSLATE_IRON_ORE
+  - DEEPSLATE_GOLD_ORE
+  - DEEPSLATE_REDSTONE_ORE
+  - DEEPSLATE_LAPIS_ORE
+  - DEEPSLATE_DIAMOND_ORE
+  - DEEPSLATE_EMERALD_ORE
+crops:
+  - WHEAT
+  - CARROTS
+  - POTATOES
+  - BEETROOTS
+  - NETHER_WART
+  - COCOA
+  - SWEET_BERRY_BUSH
+respawn_seconds: 20
 farmxmine:
   direct_to_inventory: true
 inventory:
@@ -26,7 +51,6 @@ bossbar:
   enabled: true
   color: BLUE
   style: SOLID
-  timeout_idle_seconds: 10
   timeout_active_seconds: 30
   title_mining: '&6Mining'
   title_farming: '&aFarming'


### PR DESCRIPTION
## Summary
- Honor configured ore/crop lists and per-player instancing, including override options and safe respawn
- Restore farming/mining XP progression with level-up alerts and sounds
- Simplify boss bar handling to a single 30s inactivity timeout

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68a744a14a60832584b77458779c0218