### PR TITLE
Fix personal block break handling and XP scaling

### DIFF
--- a/FarmXMine/src/main/java/com/farmxmine/service/InstancingService.java
+++ b/FarmXMine/src/main/java/com/farmxmine/service/InstancingService.java
@@ -137,14 +137,14 @@ public class InstancingService implements Listener {
     }
 
     private void handle(BlockBreakEvent event, Player player, Block block, Location loc, Set<Location> set, boolean mining) {
-        int xpFromEvent = event.getExpToDrop();
+        int count = computeCount(player, mining);
+        int xpFromEvent = event.getExpToDrop() * count;
 
         // Serverzustand nicht ändern → abbrechen & eigene Drops/XP geben
         event.setCancelled(true);
         event.setDropItems(false);
         event.setExpToDrop(0);
 
-        int count = computeCount(player, mining);
         ItemStack tool = player.getInventory().getItemInMainHand();
 
         // Drops simulieren (inkl. Fortune/Verzauberungen via getDrops)
@@ -164,9 +164,7 @@ public class InstancingService implements Listener {
         }
 
         // Spieler-Client: Block optisch ersetzen (Fake Break)
-        BlockData replacement = mining
-                ? (block.getType().name().startsWith("DEEPSLATE_") ? Material.DEEPSLATE : Material.STONE).createBlockData()
-                : Material.AIR.createBlockData();
+        BlockData replacement = Material.AIR.createBlockData();
 
         set.add(loc);
         sendBlockChange(player, block, replacement);


### PR DESCRIPTION
## Summary
- Ensure per-player mining/farming blocks vanish as air and reappear after delay
- Scale XP and bossbar progress with multi-block counts

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68a753f82ef08325a9cc69cf20477055