### PR TITLE
Group template items by rarity rows

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/listeners/GuiListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/GuiListener.java
@@ -63,13 +63,13 @@ public class GuiListener implements Listener {
             page = Integer.parseInt(left) - 1;
         } catch (Exception ignored) {}
 
-        if (raw == 45) { // prev
+        if (raw == 0) { // prev
             TemplateGUI.open(p, Math.max(0, page - 1));
             return;
-        } else if (raw == 49) { // close
+        } else if (raw == 4) { // close
             p.closeInventory();
             return;
-        } else if (raw == 53) { // next
+        } else if (raw == 8) { // next
             TemplateGUI.open(p, page + 1);
             return;
         }


### PR DESCRIPTION
## Summary
- Organize template GUI by item rarity, mapping each rarity to its own row from bottom (Common) to top (Legendary)
- Move navigation controls to the top row and update listener to handle new slots

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68a88d86c3648325b14d99dffcd7e5b0