### PR TITLE
Implement per-player respawn and region checks

### DIFF
--- a/FarmXMine2/src/main/java/com/farmxmine2/listener/BlockListener.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/listener/BlockListener.java
@@ -15,7 +15,6 @@ public class BlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onBreak(BlockBreakEvent event) {
-        harvestService.handle(event.getPlayer(), event.getBlock());
-        event.setCancelled(true);
+        harvestService.handleBlockBreak(event.getPlayer(), event.getBlock(), event);
     }
 }

--- a/FarmXMine2/src/main/java/com/farmxmine2/listener/BlockListenerOverride.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/listener/BlockListenerOverride.java
@@ -15,8 +15,6 @@ public class BlockListenerOverride implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     public void onBreak(BlockBreakEvent event) {
-        if (!event.isCancelled()) return;
-        harvestService.handle(event.getPlayer(), event.getBlock());
-        event.setCancelled(true);
+        harvestService.handleBlockBreak(event.getPlayer(), event.getBlock(), event);
     }
 }

--- a/FarmXMine2/src/main/java/com/farmxmine2/listener/PlayerListener.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/listener/PlayerListener.java
@@ -42,7 +42,7 @@ public class PlayerListener implements Listener {
     public void onChunkUnload(ChunkUnloadEvent event) {
         Chunk chunk = event.getChunk();
         for (Player player : chunk.getWorld().getPlayers()) {
-            harvestService.clear(player); // simple: clears any views in that chunk
+            harvestService.clear(player, chunk);
         }
     }
 }

--- a/FarmXMine2/src/main/java/com/farmxmine2/model/BlockPosKey.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/model/BlockPosKey.java
@@ -1,0 +1,17 @@
+package com.farmxmine2.model;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+
+/** Simple key representing a block position in a world. */
+public record BlockPosKey(String world, int x, int y, int z) {
+    public static BlockPosKey of(Block block) {
+        Location loc = block.getLocation();
+        return new BlockPosKey(loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+    }
+
+    public Location toLocation() {
+        return new Location(Bukkit.getWorld(world), x, y, z);
+    }
+}

--- a/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
@@ -1,14 +1,17 @@
 package com.farmxmine2.service;
 
 import com.farmxmine2.FarmXMine2Plugin;
+import com.farmxmine2.model.BlockPosKey;
 import com.farmxmine2.model.Region;
 import com.farmxmine2.model.TrackType;
+import org.bukkit.Chunk;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -21,7 +24,7 @@ public class HarvestService {
     private final LevelService levelService;
     private final BossBarService bossBarService;
     private final VeinMinerCompat veinMiner;
-    private final Map<UUID, Map<Block, StoredBlock>> views = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<BlockPosKey, StoredBlock>> views = new ConcurrentHashMap<>();
 
     private record StoredBlock(BlockData data, BukkitTask task) {}
 
@@ -33,12 +36,8 @@ public class HarvestService {
         this.veinMiner = veinMiner;
     }
 
-    public void handle(Player player, Block block) {
-        TrackType track = null;
-        Region mine = regionService.getRegion(TrackType.MINE);
-        Region farm = regionService.getRegion(TrackType.FARM);
-        if (mine.contains(block.getLocation())) track = TrackType.MINE;
-        else if (farm.contains(block.getLocation())) track = TrackType.FARM;
+    public void handleBlockBreak(Player player, Block block, BlockBreakEvent event) {
+        TrackType track = regionService.getKind(block.getLocation());
         if (track == null) return;
         if (plugin.getConfig().getBoolean("general.require_permissions")) {
             if (track == TrackType.MINE && !player.hasPermission("farmxmine.mine")) return;
@@ -46,52 +45,77 @@ public class HarvestService {
         }
         ItemStack tool = player.getInventory().getItemInMainHand();
         Region region = regionService.getRegion(track);
-        if (region.getRequireTool() != null && !region.getRequireTool().isEmpty()) {
-            if (tool == null || !tool.getType().name().endsWith("_" + region.getRequireTool())) return;
+        String req = region.getRequireTool();
+        if (req != null && !req.isEmpty()) {
+            if (tool == null || !tool.getType().name().endsWith("_" + req)) return;
         }
-        if (track == TrackType.FARM) {
-            BlockData data = block.getBlockData();
-            if (data instanceof Ageable age) {
-                if (age.getAge() != age.getMaximumAge()) return;
-            }
+        BlockData data = block.getBlockData();
+        if (track == TrackType.FARM && data instanceof Ageable age && age.getAge() != age.getMaximumAge()) {
+            return;
         }
         if (track == TrackType.MINE && veinMiner.hasVeinMiner(tool)) {
             Set<Block> blocks = veinMiner.collect(block, region);
             for (Block b : blocks) {
-                processBlock(player, b, region, track, tool);
+                processBlock(player, b, region, track, tool, event);
             }
         } else {
-            processBlock(player, block, region, track, tool);
+            processBlock(player, block, region, track, tool, event);
         }
     }
 
-    private void processBlock(Player player, Block block, Region region, TrackType track, ItemStack tool) {
+    private void processBlock(Player player, Block block, Region region, TrackType track, ItemStack tool, BlockBreakEvent event) {
         if (!region.isAllowed(block.getType())) return;
+        event.setCancelled(true);
         BlockData original = block.getBlockData();
+        final BlockData restore;
+        if (track == TrackType.FARM && original instanceof Ageable age) {
+            Ageable clone = (Ageable) age.clone();
+            clone.setAge(clone.getMaximumAge());
+            restore = clone;
+        } else {
+            restore = original;
+        }
         Collection<ItemStack> drops = block.getDrops(tool, player);
         for (ItemStack drop : drops) {
             player.getInventory().addItem(drop);
         }
         player.sendBlockChange(block.getLocation(), Material.AIR.createBlockData());
         long delay = plugin.getConfig().getInt("general.respawn_seconds") * 20L;
-        Map<Block, StoredBlock> playerMap = views.computeIfAbsent(player.getUniqueId(), id -> new HashMap<>());
+        Map<BlockPosKey, StoredBlock> playerMap = views.computeIfAbsent(player.getUniqueId(), id -> new HashMap<>());
+        BlockPosKey key = BlockPosKey.of(block);
         BukkitTask task = Bukkit.getScheduler().runTaskLater(plugin, () -> {
-            player.sendBlockChange(block.getLocation(), original);
-            playerMap.remove(block);
+            player.sendBlockChange(key.toLocation(), restore);
+            playerMap.remove(key);
         }, delay);
-        playerMap.put(block, new StoredBlock(original, task));
+        playerMap.put(key, new StoredBlock(restore, task));
         levelService.addXp(player, track);
     }
 
     public void clear(Player player) {
-        Map<Block, StoredBlock> map = views.remove(player.getUniqueId());
+        Map<BlockPosKey, StoredBlock> map = views.remove(player.getUniqueId());
         if (map != null) {
-            for (Map.Entry<Block, StoredBlock> e : map.entrySet()) {
+            for (Map.Entry<BlockPosKey, StoredBlock> e : map.entrySet()) {
                 e.getValue().task.cancel();
-                player.sendBlockChange(e.getKey().getLocation(), e.getValue().data);
+                player.sendBlockChange(e.getKey().toLocation(), e.getValue().data);
             }
         }
         bossBarService.remove(player);
+    }
+
+    public void clear(Player player, Chunk chunk) {
+        Map<BlockPosKey, StoredBlock> map = views.get(player.getUniqueId());
+        if (map == null) return;
+        Iterator<Map.Entry<BlockPosKey, StoredBlock>> it = map.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<BlockPosKey, StoredBlock> e = it.next();
+            BlockPosKey key = e.getKey();
+            if (key.world().equalsIgnoreCase(chunk.getWorld().getName()) &&
+                    (key.x() >> 4) == chunk.getX() && (key.z() >> 4) == chunk.getZ()) {
+                e.getValue().task.cancel();
+                player.sendBlockChange(key.toLocation(), e.getValue().data);
+                it.remove();
+            }
+        }
     }
 
     public void clearAll() {

--- a/FarmXMine2/src/main/java/com/farmxmine2/service/RegionService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/RegionService.java
@@ -4,6 +4,7 @@ import com.farmxmine2.FarmXMine2Plugin;
 import com.farmxmine2.model.Region;
 import com.farmxmine2.model.TrackType;
 import com.farmxmine2.model.Vec3i;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -46,5 +47,24 @@ public class RegionService {
 
     public Region getRegion(TrackType type) {
         return regions.get(type);
+    }
+
+    /**
+     * Determine which configured track a location falls into.
+     * Only the main world "world" is considered valid.
+     *
+     * @param loc location to test
+     * @return matching TrackType or null if none
+     */
+    public TrackType getKind(Location loc) {
+        if (loc.getWorld() == null || !"world".equalsIgnoreCase(loc.getWorld().getName())) {
+            return null;
+        }
+        for (Map.Entry<TrackType, Region> entry : regions.entrySet()) {
+            if (entry.getValue().contains(loc)) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 }

--- a/FarmXMine2/src/main/resources/config.yml
+++ b/FarmXMine2/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 general:
-  respawn_seconds: 30
+  respawn_seconds: 20
   play_sounds: false
   require_permissions: false
   override_cancelled: false


### PR DESCRIPTION
## Summary
- Handle block breaks via service with respect and override listeners
- Track per-player fake breaks and restore blocks after 20s
- Add world-gated region detection and adjustable respawn default

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68a89ad1b2948325b2745767b2353700