### PR TITLE
Add default ores fallback for FarmXMine2 mining

### DIFF
--- a/FarmXMine/src/main/java/com/farmxmine/service/InstancingService.java
+++ b/FarmXMine/src/main/java/com/farmxmine/service/InstancingService.java
@@ -21,6 +21,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +60,29 @@ public class InstancingService implements Listener {
     // pro Spieler versteckte Blockpositionen
     private final Map<UUID, Set<Location>> hidden = new HashMap<>();
 
+    // Fallback-Liste aller Vanilla-Erze (1.21.4)
+    private static final Material[] DEFAULT_ORES = {
+            Material.COAL_ORE,
+            Material.IRON_ORE,
+            Material.COPPER_ORE,
+            Material.GOLD_ORE,
+            Material.REDSTONE_ORE,
+            Material.DIAMOND_ORE,
+            Material.EMERALD_ORE,
+            Material.LAPIS_ORE,
+            Material.DEEPSLATE_COAL_ORE,
+            Material.DEEPSLATE_IRON_ORE,
+            Material.DEEPSLATE_COPPER_ORE,
+            Material.DEEPSLATE_GOLD_ORE,
+            Material.DEEPSLATE_REDSTONE_ORE,
+            Material.DEEPSLATE_DIAMOND_ORE,
+            Material.DEEPSLATE_EMERALD_ORE,
+            Material.DEEPSLATE_LAPIS_ORE,
+            Material.NETHER_QUARTZ_ORE,
+            Material.NETHER_GOLD_ORE,
+            Material.ANCIENT_DEBRIS
+    };
+
     public InstancingService(JavaPlugin plugin, LevelService level, ArtifactService artifacts) {
         this.plugin = plugin;
         this.level = level;
@@ -71,7 +95,7 @@ public class InstancingService implements Listener {
 
         // Ores/Crops laden (robust) + Defaults
         Set<Material> tmpOres = loadMaterials("regions.mine.ores", "mine.ores", "ores");
-        if (tmpOres.isEmpty()) tmpOres.add(Material.COAL_ORE);
+        if (tmpOres.isEmpty()) tmpOres.addAll(Arrays.asList(DEFAULT_ORES));
         this.ores = tmpOres;
 
         Set<Material> tmpCrops = loadMaterials("regions.farm.crops", "farm.crops", "crops");

--- a/FarmXMine2/src/main/java/com/farmxmine2/service/ConfigService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/ConfigService.java
@@ -1,9 +1,12 @@
 package com.farmxmine2.service;
 
 import com.farmxmine2.FarmXMine2Plugin;
+import com.farmxmine2.util.Materials;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 
+import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,10 +39,26 @@ public class ConfigService {
         overrideCancelled = cfg.getBoolean("general.override_cancelled");
         miningEnabled = cfg.getBoolean("mining.enabled");
         miningRequireTool = cfg.getString("mining.require_tool", "PICKAXE");
-        miningOres = cfg.getStringList("mining.ores").stream().map(Material::valueOf).collect(Collectors.toSet());
+        miningOres = cfg.getStringList("mining.ores").stream()
+                .map(s -> {
+                    try { return Material.valueOf(s); } catch (IllegalArgumentException ex) { return null; }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Material.class)));
+        if (miningOres.isEmpty()) {
+            miningOres = Materials.allOres();
+        }
         farmingEnabled = cfg.getBoolean("farming.enabled");
         farmingRequireTool = cfg.getString("farming.require_tool", "HOE");
-        farmingCrops = cfg.getStringList("farming.crops").stream().map(Material::valueOf).collect(Collectors.toSet());
+        farmingCrops = cfg.getStringList("farming.crops").stream()
+                .map(s -> {
+                    try { return Material.valueOf(s); } catch (IllegalArgumentException ex) { return null; }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(Material.class)));
+        if (farmingCrops.isEmpty()) {
+            farmingCrops = Materials.allCrops();
+        }
         mineXpPer = cfg.getInt("leveling.xp_per_harvest.mine");
         farmXpPer = cfg.getInt("leveling.xp_per_harvest.farm");
         baseXpPerLevel = cfg.getInt("leveling.base_xp_per_level");

--- a/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
@@ -47,8 +47,8 @@ public class HarvestService {
         }
 
         Material type = b.getType();
-        boolean isOre = config.isMiningEnabled() && Materials.isOre(type);
-        boolean isCrop = config.isFarmingEnabled() && Materials.isCrop(type) && Materials.isMature(b);
+        boolean isOre = config.isMiningEnabled() && config.getMiningOres().contains(type);
+        boolean isCrop = config.isFarmingEnabled() && config.getFarmingCrops().contains(type) && Materials.isMature(b);
         if (!isOre && !isCrop) {
             return;
         }
@@ -154,8 +154,8 @@ public class HarvestService {
             return;
         }
         Material type = b.getType();
-        boolean isOre = config.isMiningEnabled() && Materials.isOre(type);
-        boolean isCrop = config.isFarmingEnabled() && Materials.isCrop(type) && Materials.isMature(b);
+        boolean isOre = config.isMiningEnabled() && config.getMiningOres().contains(type);
+        boolean isCrop = config.isFarmingEnabled() && config.getFarmingCrops().contains(type) && Materials.isMature(b);
         if (!isOre && !isCrop) {
             return;
         }
@@ -175,8 +175,8 @@ public class HarvestService {
             return;
         }
         Material type = b.getType();
-        boolean isOre = config.isMiningEnabled() && Materials.isOre(type);
-        boolean isCrop = config.isFarmingEnabled() && Materials.isCrop(type) && Materials.isMature(b);
+        boolean isOre = config.isMiningEnabled() && config.getMiningOres().contains(type);
+        boolean isCrop = config.isFarmingEnabled() && config.getFarmingCrops().contains(type) && Materials.isMature(b);
         if (!isOre && !isCrop) {
             return;
         }

--- a/FarmXMine2/src/main/java/com/farmxmine2/util/Materials.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/util/Materials.java
@@ -54,5 +54,15 @@ public final class Materials {
     public static boolean isMineableByPickaxe(Material mat) {
         return Tag.MINEABLE_PICKAXE.isTagged(mat) || ORE_ALLOWLIST.contains(mat);
     }
+
+    /** Returns an independent set of all default ores. */
+    public static Set<Material> allOres() {
+        return EnumSet.copyOf(ORE_ALLOWLIST);
+    }
+
+    /** Returns an independent set of all default crops. */
+    public static Set<Material> allCrops() {
+        return EnumSet.copyOf(CROPS);
+    }
 }
 


### PR DESCRIPTION
## Summary
- expose full vanilla ore and crop sets
- load mining and farming blocks from config with vanilla fallback
- validate mining and farming checks against configured sets

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e3d6ae483258d08ff688b4d3f47