### PR TITLE
Normalize custom model data numbers

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/debug/SiCmdFix.java
+++ b/SpecialItems/src/main/java/com/specialitems/debug/SiCmdFix.java
@@ -1,13 +1,13 @@
 package com.specialitems.debug;
 import org.bukkit.command.*; import org.bukkit.entity.Player;
-import org.bukkit.inventory.*; import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.*; import org.bukkit.inventory.meta.ItemMeta; import java.util.Map;
 public final class SiCmdFix implements CommandExecutor{
   @Override public boolean onCommand(CommandSender s, Command c, String l, String[] a){
     if(!(s instanceof Player p)){ s.sendMessage("Player only"); return true; }
     ItemStack it=p.getInventory().getItemInMainHand();
     if(it==null||it.getType().isAir()){ p.sendMessage("Hold an item."); return true; }
-    ItemMeta m=it.getItemMeta(); Integer v=(m!=null?m.getCustomModelData():null);
-    if(m!=null&&v!=null){ m.setCustomModelData(null); m.setCustomModelData(v); it.setItemMeta(m); p.sendMessage("CustomModelData normalized to integer: "+v); }
+    ItemMeta m=it.getItemMeta(); Map<String,Object> metaMap=(m!=null?m.serialize():null); Object raw=(metaMap!=null?metaMap.get("custom-model-data"):null);
+    if(m!=null&&raw instanceof Number){ int v=((Number)raw).intValue(); m.setCustomModelData(v); it.setItemMeta(m); p.getInventory().setItemInMainHand(it); p.sendMessage("CustomModelData normalized to integer: "+v); }
     else p.sendMessage("No CMD on this item.");
     return true;
   }


### PR DESCRIPTION
## Summary
- Handle non-integer custom-model-data in SiCmdFix
- Update item in hand so client sees new model data

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6d2288ec83258815797ec508e884