### PR TITLE
Ensure SpecialItems template CMD is parsed as integers

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/debug/SiCmdFix.java
+++ b/SpecialItems/src/main/java/com/specialitems/debug/SiCmdFix.java
@@ -8,7 +8,11 @@ public final class SiCmdFix implements CommandExecutor{
     if(it==null||it.getType().isAir()){ p.sendMessage("Hold an item."); return true; }
     ItemMeta m=it.getItemMeta(); Map<String,Object> metaMap=(m!=null?m.serialize():null); Object raw=(metaMap!=null?metaMap.get("custom-model-data"):null);
 
-    if(m!=null&&raw instanceof Number){ int v=((Number)raw).intValue(); m.setCustomModelData(null); it.setItemMeta(m); m=it.getItemMeta(); if(m!=null){ m.setCustomModelData(v); it.setItemMeta(m); } p.getInventory().setItemInMainHand(it); p.sendMessage("CustomModelData normalized to integer: "+v); }
+    Integer val=null;
+    if(raw instanceof Number n) val=n.intValue();
+    else if(raw instanceof String str){ str=str.trim(); if(str.matches("\\d+")) val=Integer.parseInt(str); }
+
+    if(m!=null&&val!=null){ m.setCustomModelData(null); it.setItemMeta(m); m=it.getItemMeta(); if(m!=null){ m.setCustomModelData(val); it.setItemMeta(m); } p.getInventory().setItemInMainHand(it); p.sendMessage("CustomModelData normalized to integer: "+val); }
 
     else if(TemplateItems.applyTemplateMeta(it)){ p.getInventory().setItemInMainHand(it); p.sendMessage("CustomModelData applied from template."); }
     else p.sendMessage("No CMD on this item.");

--- a/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
@@ -67,7 +67,7 @@ public final class TemplateItems {
             }
         }
 
-        Integer cmd = readCmd(t);
+        Integer cmd = readModelData(t);
         if (cmd == null) cmd = computeCmdFallback(mat, t.getString("rarity"));
         if (cmd != null) {
             org.bukkit.inventory.meta.ItemMeta m = it.getItemMeta();
@@ -97,11 +97,24 @@ public final class TemplateItems {
         return new TemplateItem(id, it, cmd);
     }
 
-    private static Integer readCmd(ConfigurationSection t) {
+    private static Integer readModelData(ConfigurationSection t) {
         if (t == null) return null;
-        if (t.isInt("custom_model_data")) return t.getInt("custom_model_data");
-        if (t.isInt("model-data")) return t.getInt("model-data");
-        if (t.isInt("model_data")) return t.getInt("model_data");
+        Integer v = readModelDataKey(t, "custom_model_data");
+        if (v != null) return v;
+        v = readModelDataKey(t, "model-data");
+        if (v != null) return v;
+        return readModelDataKey(t, "model_data");
+    }
+
+    private static Integer readModelDataKey(ConfigurationSection sec, String key) {
+        if (sec.isInt(key)) return sec.getInt(key);
+        Object raw = sec.get(key);
+        if (raw == null) return null;
+        if (raw instanceof Number n) return n.intValue();
+        if (raw instanceof String s) {
+            s = s.trim();
+            if (s.matches("\\d+")) return Integer.parseInt(s);
+        }
         return null;
     }
 


### PR DESCRIPTION
## Summary
- Normalize `custom_model_data` parsing to always return an `Integer`
- Guard debug fixer command to handle numeric strings when normalizing custom model data

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8216cde4832584e3c79944485dd1