### PR TITLE
Normalize custom model data handling to integers

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/util/ItemUtil.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/ItemUtil.java
@@ -4,6 +4,7 @@ import com.specialitems.SpecialItemsPlugin;
 import com.specialitems.effects.Effects;
 import org.bukkit.ChatColor;
 import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -61,6 +62,20 @@ public final class ItemUtil {
         } catch (Throwable ignored) {
             return 0.0;
         }
+    }
+
+    public static Integer readInt(ConfigurationSection sec, String path) {
+        Object raw = sec.get(path);
+        if (raw == null) return null;
+        if (raw instanceof Number n) return n.intValue();
+        if (raw instanceof String s) {
+            s = s.trim();
+            if (s.matches("\\d+(\\.0+)?")) {
+                int dot = s.indexOf('.');
+                return Integer.parseInt(dot >= 0 ? s.substring(0, dot) : s);
+            }
+        }
+        return null;
     }
 
     public static void removeLoreLinePrefix(List<String> lore, String prefix) {

--- a/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
@@ -99,23 +99,11 @@ public final class TemplateItems {
 
     private static Integer readModelData(ConfigurationSection t) {
         if (t == null) return null;
-        Integer v = readModelDataKey(t, "custom_model_data");
+        Integer v = ItemUtil.readInt(t, "custom_model_data");
         if (v != null) return v;
-        v = readModelDataKey(t, "model-data");
+        v = ItemUtil.readInt(t, "model-data");
         if (v != null) return v;
-        return readModelDataKey(t, "model_data");
-    }
-
-    private static Integer readModelDataKey(ConfigurationSection sec, String key) {
-        if (sec.isInt(key)) return sec.getInt(key);
-        Object raw = sec.get(key);
-        if (raw == null) return null;
-        if (raw instanceof Number n) return n.intValue();
-        if (raw instanceof String s) {
-            s = s.trim();
-            if (s.matches("\\d+")) return Integer.parseInt(s);
-        }
-        return null;
+        return ItemUtil.readInt(t, "model_data");
     }
 
     private static Integer computeCmdFallback(org.bukkit.Material mat, String rarityStr) {


### PR DESCRIPTION
## Summary
- Add `ItemUtil.readInt` to robustly parse integers from config values
- Use `ItemUtil.readInt` for template custom_model_data lookups
- Ensure item meta sets custom model data only with integers

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ab83b7f2e88325aa3e972fe27d1ba6