### PR TITLE
Search crate keys in off-hand or inventory

### DIFF
--- a/LootCrates_v1.2/src/main/java/com/lootcrates/command/CrateCommand.java
+++ b/LootCrates_v1.2/src/main/java/com/lootcrates/command/CrateCommand.java
@@ -53,7 +53,7 @@ public class CrateCommand implements CommandExecutor {
                 if (args.length < 2){ p.sendMessage("§cUsage: /crate open <CRATE>"); return true; }
                 Crate c = plugin.crates().get(args[1]);
                 if (c == null){ p.sendMessage("§cUnknown crate."); return true; }
-                GUI.tryOpenWithKey(plugin, p, c);
+                GUI.tryOpenWithKey(plugin, p, c, true);
             }
             case "preview" -> {
                 if (!(sender instanceof Player p)){ sender.sendMessage("§cPlayers only."); return true; }

--- a/LootCrates_v1.2/src/main/java/com/lootcrates/listener/CrateBlockListener.java
+++ b/LootCrates_v1.2/src/main/java/com/lootcrates/listener/CrateBlockListener.java
@@ -33,7 +33,7 @@ public class CrateBlockListener implements Listener {
         if (a == Action.RIGHT_CLICK_BLOCK){
             GUI.preview(p, c);
         } else if (a == Action.LEFT_CLICK_BLOCK){
-            GUI.tryOpenWithKey(plugin, p, c);
+            GUI.tryOpenWithKey(plugin, p, c, false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Allow `tryOpenWithKey` to optionally search the entire inventory for a key
- Consume keys from main hand, off-hand, or inventory and report the slot used
- Adjust command and block listener to use the new search option

## Testing
- `gradle test` *(fails: TemplateItem cannot be converted to ItemStack)*

------
https://chatgpt.com/codex/tasks/task_e_68ac929cbe188325ba639e6baa5589d5