### PR TITLE
Ensure GUI template items write integer CustomModelData

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/listeners/GuiListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/GuiListener.java
@@ -4,6 +4,7 @@ import com.specialitems.bin.Bin;
 import com.specialitems.gui.BinGUI;
 import com.specialitems.gui.TemplateGUI;
 import com.specialitems.util.Configs;
+import com.specialitems.util.TemplateItems;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -79,7 +80,10 @@ public class GuiListener implements Listener {
         // Item click -> give
         ItemStack clicked = e.getCurrentItem();
         if (clicked == null) return;
-        p.getInventory().addItem(clicked.clone());
+        ItemStack give = clicked.clone();
+        // Reapply template data so custom model data is written as an integer
+        TemplateItems.applyTemplateMeta(give);
+        p.getInventory().addItem(give);
         p.sendMessage(ChatColor.GREEN + "Given: " + (clicked.getItemMeta()!=null ? clicked.getItemMeta().getDisplayName() : clicked.getType().name()));
     }
 }


### PR DESCRIPTION
## Summary
- Reapply template metadata when giving items from the template GUI so CustomModelData is written via the Bukkit API as an integer

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8dc481008325be8a123b69d29c01