### PR TITLE
Handle float and double suffix in numeric strings

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/util/ItemUtil.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/ItemUtil.java
@@ -75,9 +75,8 @@ public final class ItemUtil {
         if (raw instanceof Number n) return n.intValue();
         if (raw instanceof String s) {
             s = s.trim();
-            if (s.matches("\\d+(\\.0+)?")) {
-                int dot = s.indexOf('.');
-                return Integer.parseInt(dot >= 0 ? s.substring(0, dot) : s);
+            if (s.matches("^\\d+(?:\\.\\d+)?[fFdD]?$")) {
+                return (int) Double.parseDouble(s);
             }
         }
         return null;


### PR DESCRIPTION
## Summary
- expand ItemUtil numeric parsing to accept decimal strings with optional float/double suffix and parse via `Double.parseDouble`

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68acae15003083258875a54131c05781