### PR TITLE
Handle CustomModelData via DataComponents

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/debug/SiCmdFix.java
+++ b/SpecialItems/src/main/java/com/specialitems/debug/SiCmdFix.java
@@ -24,30 +24,25 @@ public final class SiCmdFix implements CommandExecutor {
             Class<?> craft = Class.forName("org.bukkit.craftbukkit.inventory.CraftItemStack");
             var asNmsCopy = craft.getMethod("asNMSCopy", ItemStack.class);
             Object nms = asNmsCopy.invoke(null, it);
-            // New data-component based storage introduced in 1.20+ uses namespaced keys
-            // such as "minecraft:custom_model_data".  Check for this first and strip it.
+            // Use the 1.20+ data component system if present
             try {
-                var getComponents = nms.getClass().getMethod("getComponents");
-                Object comps = getComponents.invoke(nms);
-                if (comps != null) {
-                    var contains = comps.getClass().getMethod("contains", String.class);
-                    String key = "minecraft:custom_model_data";
-                    if ((Boolean) contains.invoke(comps, key)) {
-                        var get = comps.getClass().getMethod("get", String.class);
-                        Object raw = get.invoke(comps, key);
-                        double dbl;
-                        try { dbl = (double) raw.getClass().getMethod("asDouble").invoke(raw); }
-                        catch (NoSuchMethodException ex) { dbl = Double.parseDouble(raw.toString()); }
-                        val = (int) Math.round(dbl);
-                        var remove = comps.getClass().getMethod("remove", String.class);
-                        remove.invoke(comps, key);
-                        var setComponents = nms.getClass().getMethod("setComponents", comps.getClass());
-                        setComponents.invoke(nms, comps);
-                        var asBukkitCopy = craft.getMethod("asBukkitCopy", nms.getClass());
-                        ItemStack cleaned = (ItemStack) asBukkitCopy.invoke(null, nms);
-                        m = cleaned.getItemMeta();
-                        it.setItemMeta(m);
-                    }
+                Class<?> comps = Class.forName("net.minecraft.world.item.component.DataComponents");
+                Object type = comps.getField("CUSTOM_MODEL_DATA").get(null);
+                var has = nms.getClass().getMethod("has", type.getClass());
+                if ((Boolean) has.invoke(nms, type)) {
+                    var get = nms.getClass().getMethod("get", type.getClass());
+                    Object comp = get.invoke(nms, type);
+                    Object raw;
+                    try { raw = comp.getClass().getMethod("intValue").invoke(comp); }
+                    catch (NoSuchMethodException ex) { raw = comp.getClass().getMethod("value").invoke(comp); }
+                    double dbl = ((Number) raw).doubleValue();
+                    val = (int) Math.round(dbl);
+                    var remove = nms.getClass().getMethod("remove", type.getClass());
+                    remove.invoke(nms, type);
+                    var asBukkitCopy = craft.getMethod("asBukkitCopy", nms.getClass());
+                    ItemStack cleaned = (ItemStack) asBukkitCopy.invoke(null, nms);
+                    m = cleaned.getItemMeta();
+                    it.setItemMeta(m);
                 }
             } catch (Throwable ignored) {}
 

--- a/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
@@ -164,20 +164,15 @@ public final class TemplateItems {
             Object nms = asNmsCopy.invoke(null, item);
             // Strip the data-component based field introduced in 1.20+
             try {
-                var getComponents = nms.getClass().getMethod("getComponents");
-                Object comps = getComponents.invoke(nms);
-                if (comps != null) {
-                    var contains = comps.getClass().getMethod("contains", String.class);
-                    String compKey = "minecraft:custom_model_data";
-                    if ((Boolean) contains.invoke(comps, compKey)) {
-                        var remove = comps.getClass().getMethod("remove", String.class);
-                        remove.invoke(comps, compKey);
-                        var setComponents = nms.getClass().getMethod("setComponents", comps.getClass());
-                        setComponents.invoke(nms, comps);
-                        var asBukkitCopy = craft.getMethod("asBukkitCopy", nms.getClass());
-                        ItemStack cleaned = (ItemStack) asBukkitCopy.invoke(null, nms);
-                        item.setItemMeta(cleaned.getItemMeta());
-                    }
+                Class<?> comps = Class.forName("net.minecraft.world.item.component.DataComponents");
+                Object type = comps.getField("CUSTOM_MODEL_DATA").get(null);
+                var has = nms.getClass().getMethod("has", type.getClass());
+                if ((Boolean) has.invoke(nms, type)) {
+                    var remove = nms.getClass().getMethod("remove", type.getClass());
+                    remove.invoke(nms, type);
+                    var asBukkitCopy = craft.getMethod("asBukkitCopy", nms.getClass());
+                    ItemStack cleaned = (ItemStack) asBukkitCopy.invoke(null, nms);
+                    item.setItemMeta(cleaned.getItemMeta());
                 }
             } catch (Throwable ignored) {}
             // Legacy NBT tag fallback for older items


### PR DESCRIPTION
## Summary
- Normalize `CustomModelData` using the 1.20+ DataComponents API
- Remove legacy data component and NBT entries before reapplying integer CMD values

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68acbfb8a7ec83259bfc0000637b4ceb