### PR TITLE
Add mining cooldown messaging and tool checks

### DIFF
--- a/FarmXMine2/src/main/java/com/farmxmine2/service/CooldownService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/CooldownService.java
@@ -25,6 +25,21 @@ public class CooldownService {
         return true;
     }
 
+    /** Returns remaining cooldown in milliseconds or 0 if none. */
+    public long getRemaining(UUID uuid, BlockKey key) {
+        Map<BlockKey, Long> map = cooldowns.get(uuid);
+        if (map == null) return 0L;
+        Long end = map.get(key);
+        if (end == null) return 0L;
+        long remaining = end - System.currentTimeMillis();
+        if (remaining <= 0L) {
+            map.remove(key);
+            if (map.isEmpty()) cooldowns.remove(uuid);
+            return 0L;
+        }
+        return remaining;
+    }
+
     public void start(UUID uuid, BlockKey key, long endMs) {
         Map<BlockKey, Long> map = cooldowns.computeIfAbsent(uuid, u -> new ConcurrentHashMap<>());
         map.put(key, endMs);

--- a/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
@@ -60,8 +60,37 @@ public class HarvestService {
         BlockKey key = BlockKey.of(b);
         UUID id = p.getUniqueId();
 
+        // tool gating before cooldown start
+        if (isOre) {
+            String req = config.getMiningRequireTool();
+            if (req != null && !req.equalsIgnoreCase("NONE") && (tool == null || !tool.getType().name().endsWith("_" + req))) {
+                String msg = plugin.color(plugin.getMessages().getString("wrong-tool", "&cYou need a %tool%"))
+                        .replace("%tool%", req.toLowerCase());
+                p.sendMessage(msg);
+                e.setCancelled(true);
+                e.setDropItems(false);
+                e.setExpToDrop(0);
+                return;
+            }
+        } else if (isCrop) {
+            String req = config.getFarmingRequireTool();
+            if (req != null && !req.equalsIgnoreCase("NONE") && (tool == null || !tool.getType().name().endsWith("_" + req))) {
+                String msg = plugin.color(plugin.getMessages().getString("wrong-tool", "&cYou need a %tool%"))
+                        .replace("%tool%", req.toLowerCase());
+                p.sendMessage(msg);
+                e.setCancelled(true);
+                e.setDropItems(false);
+                e.setExpToDrop(0);
+                return;
+            }
+        }
+
         // earliest cooldown and inflight gates
         if (cooldownService.isCooling(id, key)) {
+            long remaining = (cooldownService.getRemaining(id, key) + 999L) / 1000L;
+            String msg = plugin.color(plugin.getMessages().getString("cooldown", "&cWait %seconds%s"))
+                    .replace("%seconds%", String.valueOf(remaining));
+            p.sendActionBar(msg);
             if (isCrop) {
                 sendAirVisual(p, loc);
             } else {
@@ -162,6 +191,10 @@ public class HarvestService {
         BlockKey key = BlockKey.of(b);
         if (cooldownService.isCooling(p.getUniqueId(), key)) {
             e.setCancelled(true);
+            long remaining = (cooldownService.getRemaining(p.getUniqueId(), key) + 999L) / 1000L;
+            String msg = plugin.color(plugin.getMessages().getString("cooldown", "&cWait %seconds%s"))
+                    .replace("%seconds%", String.valueOf(remaining));
+            p.sendActionBar(msg);
             if (isCrop) {
                 sendAirVisual(p, b.getLocation());
             } else {
@@ -183,6 +216,10 @@ public class HarvestService {
         BlockKey key = BlockKey.of(b);
         if (cooldownService.isCooling(p.getUniqueId(), key)) {
             e.setCancelled(true);
+            long remaining = (cooldownService.getRemaining(p.getUniqueId(), key) + 999L) / 1000L;
+            String msg = plugin.color(plugin.getMessages().getString("cooldown", "&cWait %seconds%s"))
+                    .replace("%seconds%", String.valueOf(remaining));
+            p.sendActionBar(msg);
             if (isCrop) {
                 sendAirVisual(p, b.getLocation());
             } else {

--- a/FarmXMine2/src/main/resources/messages.yml
+++ b/FarmXMine2/src/main/resources/messages.yml
@@ -1,3 +1,5 @@
 prefix: "&aFarmxMine&7"
 level-up: "&aFarmxMine&7: &f%track%&7 leveled up to &a%level%&7!"
 reloaded: "&aConfig reloaded."
+cooldown: "&cWait &f%seconds%s &cbefore harvesting again."
+wrong-tool: "&cYou need a %tool% to harvest this block."


### PR DESCRIPTION
## Summary
- add remaining-time lookup to `CooldownService`
- show cooldown and tool requirement messages when mining or farming
- define message keys for cooldown and wrong tool

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68aee6d8f2848325bba72d9322633652