### PR TITLE
chore: bump SpecialItems version to 1.2.2

### DIFF
--- a/SpecialItems/build.gradle.kts
+++ b/SpecialItems/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins { java }
 
 group = "com.specialitems"
-version = "1.2.0"
+version = "1.2.2"
 
 repositories {
     mavenCentral()

--- a/SpecialItems/src/main/resources/plugin.yml
+++ b/SpecialItems/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SpecialItems
 main: com.specialitems.SpecialItemsPlugin
-version: 1.2.1
+version: 1.2.2
 api-version: 1.21
 author: You
 commands:


### PR DESCRIPTION
## Summary
- update SpecialItems version to 1.2.2 in Gradle build and plugin metadata

## Testing
- `gradle clean build`
- `unzip -p build/libs/SpecialItems-1.2.2.jar plugin.yml`

------
https://chatgpt.com/codex/tasks/task_e_68aee864fb108325920659bb66aeadff