### PR TITLE
Normalize CustomModelData after /give commands

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
+++ b/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
@@ -10,6 +10,7 @@ import com.specialitems.listeners.GuiListener;
 import com.specialitems.listeners.BinListener;
 import com.specialitems.listeners.JoinFixListener;
 import com.specialitems.listeners.InventorySanityListener;
+import com.specialitems.listeners.GiveInterceptListener;
 import com.specialitems.util.Configs;
 import com.specialitems.util.Log;
 import com.specialitems.util.TemplateItems;
@@ -62,6 +63,7 @@ public class SpecialItemsPlugin extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new JoinFixListener(), this);
             getServer().getPluginManager().registerEvents(new InventorySanityListener(), this);
             getServer().getPluginManager().registerEvents(new BinListener(this), this);
+            getServer().getPluginManager().registerEvents(new GiveInterceptListener(), this);
         } catch (Throwable t) {
             Log.warn("Listener registration failed: " + t.getMessage());
         }

--- a/SpecialItems/src/main/java/com/specialitems/listeners/GiveInterceptListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/GiveInterceptListener.java
@@ -1,0 +1,59 @@
+package com.specialitems.listeners;
+
+import com.specialitems.SpecialItemsPlugin;
+import com.specialitems.util.ItemUtil;
+import com.specialitems.util.Log;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Normalizes newly given items so that CustomModelData is stored as an integer.
+ */
+public final class GiveInterceptListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCommand(PlayerCommandPreprocessEvent e) {
+        String msg = e.getMessage();
+        if (msg == null) return;
+        msg = msg.trim();
+        if (!msg.toLowerCase(Locale.ROOT).startsWith("/give ")) return;
+
+        String[] parts = msg.split("\\s+");
+        if (parts.length < 3) return; // /give <player> <item>
+
+        Player target = Bukkit.getPlayerExact(parts[1]);
+        if (target == null) return; // not on this server
+
+        ItemStack[] before = target.getInventory().getContents().clone();
+
+        Bukkit.getScheduler().runTaskLater(SpecialItemsPlugin.getInstance(), () -> {
+            try {
+                var inv = target.getInventory();
+                ItemStack[] after = inv.getContents();
+                for (int i = 0; i < after.length; i++) {
+                    ItemStack item = after[i];
+                    if (!Objects.equals(before[i], item)) {
+                        try {
+                            if (ItemUtil.normalizeCustomModelData(item)) {
+                                inv.setItem(i, item);
+                            }
+                        } catch (Throwable t) {
+                            Log.debug("CMD normalize failed after /give", t);
+                        }
+                    }
+                }
+            } catch (Throwable t) {
+                Log.debug("Failed to process /give normalization", t);
+            }
+        }, 1L);
+    }
+}
+

--- a/SpecialItems/src/main/java/com/specialitems/util/Log.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/Log.java
@@ -1,7 +1,17 @@
 package com.specialitems.util;
+
 import org.bukkit.Bukkit;
+
+import java.util.logging.Level;
+
 public final class Log {
     public static void info(String s) { Bukkit.getLogger().info("[SpecialItems] " + s); }
     public static void warn(String s) { Bukkit.getLogger().warning("[SpecialItems] " + s); }
     public static void error(String s) { Bukkit.getLogger().severe("[SpecialItems] " + s); }
+
+    /** Logs a debug-level message which is hidden unless the server logger is set to FINE. */
+    public static void debug(String s) { Bukkit.getLogger().log(Level.FINE, "[SpecialItems] " + s); }
+
+    /** Logs a debug-level message with a stack trace. */
+    public static void debug(String s, Throwable t) { Bukkit.getLogger().log(Level.FINE, "[SpecialItems] " + s, t); }
 }


### PR DESCRIPTION
## Summary
- add GiveInterceptListener to normalize CustomModelData on items given via /give
- add debug logging helper
- register GiveInterceptListener in plugin startup

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68aee8641ce88325a2d7aac9d344250c