### PR TITLE
Remove farming cooldown message

### DIFF
--- a/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
@@ -87,10 +87,6 @@ public class HarvestService {
 
         // earliest cooldown and inflight gates
         if (cooldownService.isCooling(id, key)) {
-            long remaining = (cooldownService.getRemaining(id, key) + 999L) / 1000L;
-            String msg = plugin.color(plugin.getMessages().getString("cooldown", "&cWait %seconds%s"))
-                    .replace("%seconds%", String.valueOf(remaining));
-            p.sendActionBar(msg);
             if (isCrop) {
                 sendAirVisual(p, loc);
             } else {
@@ -191,10 +187,6 @@ public class HarvestService {
         BlockKey key = BlockKey.of(b);
         if (cooldownService.isCooling(p.getUniqueId(), key)) {
             e.setCancelled(true);
-            long remaining = (cooldownService.getRemaining(p.getUniqueId(), key) + 999L) / 1000L;
-            String msg = plugin.color(plugin.getMessages().getString("cooldown", "&cWait %seconds%s"))
-                    .replace("%seconds%", String.valueOf(remaining));
-            p.sendActionBar(msg);
             if (isCrop) {
                 sendAirVisual(p, b.getLocation());
             } else {
@@ -216,10 +208,6 @@ public class HarvestService {
         BlockKey key = BlockKey.of(b);
         if (cooldownService.isCooling(p.getUniqueId(), key)) {
             e.setCancelled(true);
-            long remaining = (cooldownService.getRemaining(p.getUniqueId(), key) + 999L) / 1000L;
-            String msg = plugin.color(plugin.getMessages().getString("cooldown", "&cWait %seconds%s"))
-                    .replace("%seconds%", String.valueOf(remaining));
-            p.sendActionBar(msg);
             if (isCrop) {
                 sendAirVisual(p, b.getLocation());
             } else {

--- a/FarmXMine2/src/main/resources/messages.yml
+++ b/FarmXMine2/src/main/resources/messages.yml
@@ -1,5 +1,4 @@
 prefix: "&aFarmxMine&7"
 level-up: "&aFarmxMine&7: &f%track%&7 leveled up to &a%level%&7!"
 reloaded: "&aConfig reloaded."
-cooldown: "&cWait &f%seconds%s &cbefore harvesting again."
 wrong-tool: "&cYou need a %tool% to harvest this block."


### PR DESCRIPTION
## Summary
- revert wait-cooldown message so harvesting uses silent cooldown visuals

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68aeeb6afe6083258b1865dc09c67614