### PR TITLE
docs: require JDK 21 for FarmXMine2

### DIFF
--- a/FarmXMine2/README.md
+++ b/FarmXMine2/README.md
@@ -4,7 +4,7 @@ Paper plugin for Minecraft 1.21.4 providing per-player fake block breaking and l
 
 ## Building
 
-Requires JDK 17 and Gradle 8+.
+Requires JDK 21 and Gradle 8+.
 
 ```
 cd FarmXMine2


### PR DESCRIPTION
## Summary
- update build instructions to require JDK 21

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68aef8e91bc88325b27f356901e41419