### PR TITLE
Add legacy placeholder aliases

### DIFF
--- a/FarmXMine2/src/main/java/com/farmxmine2/service/PlaceholderHook.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/PlaceholderHook.java
@@ -34,8 +34,10 @@ public class PlaceholderHook extends PlaceholderExpansion {
         PlayerStats ps = plugin.getLevelService().getStats(player.getUniqueId());
         return switch (identifier) {
             case "mine_level" -> String.valueOf(ps.getLevel(TrackType.MINE));
+            case "mining_level" -> String.valueOf(ps.getLevel(TrackType.MINE));
             case "mine_xp" -> String.valueOf(ps.getXp(TrackType.MINE));
             case "farm_level" -> String.valueOf(ps.getLevel(TrackType.FARM));
+            case "farming_level" -> String.valueOf(ps.getLevel(TrackType.FARM));
             case "farm_xp" -> String.valueOf(ps.getXp(TrackType.FARM));
             default -> null;
         };


### PR DESCRIPTION
## Summary
- Support legacy identifiers `mining_level` and `farming_level` by mapping them to the existing mine/farm level placeholders

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68aefaeb13408325b7f3a3df69dd76c7