### PR TITLE
Show stone to miner during cooldown

### DIFF
--- a/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
+++ b/FarmXMine2/src/main/java/com/farmxmine2/service/HarvestService.java
@@ -154,7 +154,11 @@ public class HarvestService {
             b.setType(Material.AIR, false);
             BlockData air = Bukkit.createBlockData(Material.AIR);
             for (Player online : Bukkit.getOnlinePlayers()) {
-                online.sendBlockChange(loc, air);
+                if (online.getUniqueId().equals(id)) {
+                    sendStoneVisual(online, loc);
+                } else {
+                    online.sendBlockChange(loc, air);
+                }
             }
 
             // drops already determined before cooldown


### PR DESCRIPTION
## Summary
- display stone to the player who mined an ore while cooldown runs

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68aef3dd21448325bc1e1ff837cb76e3