### PR TITLE
Add LootPets plugin skeleton

### DIFF
--- a/LootPets/build.gradle.kts
+++ b/LootPets/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins { java }
+
+group = "com.lootpets"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+}
+
+java {
+    toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+    options.release.set(21)
+}

--- a/LootPets/settings.gradle.kts
+++ b/LootPets/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "LootPets"

--- a/LootPets/src/main/java/com/lootpets/LootPetsPlugin.java
+++ b/LootPets/src/main/java/com/lootpets/LootPetsPlugin.java
@@ -1,0 +1,63 @@
+package com.lootpets;
+
+import com.lootpets.command.PetsCommand;
+import com.lootpets.gui.PetsGUI;
+import com.lootpets.service.PetService;
+import com.lootpets.service.RarityRegistry;
+import com.lootpets.service.SlotService;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.Objects;
+
+public class LootPetsPlugin extends JavaPlugin {
+
+    private FileConfiguration lang;
+    private RarityRegistry rarityRegistry;
+    private SlotService slotService;
+    private PetService petService;
+    private PetsGUI petsGUI;
+
+    @Override
+    public void onEnable() {
+        getDataFolder().mkdirs();
+        saveDefaultConfig();
+        saveResource("lang.yml", false);
+        File petsFile = new File(getDataFolder(), "pets.yml");
+        if (!petsFile.exists()) {
+            saveResource("pets.yml", false);
+        }
+        lang = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "lang.yml"));
+
+        rarityRegistry = new RarityRegistry(this);
+        slotService = new SlotService(this);
+        petService = new PetService(this);
+        petsGUI = new PetsGUI(this, slotService);
+
+        Objects.requireNonNull(getCommand("pets"), "pets command").setExecutor(new PetsCommand(this, petsGUI));
+
+        if (rarityRegistry.isFallback()) {
+            getLogger().warning("Registered fallback rarity");
+        } else {
+            getLogger().info("Imported " + rarityRegistry.size() + " rarities from SpecialItems");
+        }
+    }
+
+    public FileConfiguration getLang() {
+        return lang;
+    }
+
+    public RarityRegistry getRarityRegistry() {
+        return rarityRegistry;
+    }
+
+    public SlotService getSlotService() {
+        return slotService;
+    }
+
+    public PetService getPetService() {
+        return petService;
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/command/PetsCommand.java
+++ b/LootPets/src/main/java/com/lootpets/command/PetsCommand.java
@@ -1,0 +1,31 @@
+package com.lootpets.command;
+
+import com.lootpets.LootPetsPlugin;
+import com.lootpets.gui.PetsGUI;
+import com.lootpets.util.Colors;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class PetsCommand implements CommandExecutor {
+
+    private final LootPetsPlugin plugin;
+    private final PetsGUI gui;
+
+    public PetsCommand(LootPetsPlugin plugin, PetsGUI gui) {
+        this.plugin = plugin;
+        this.gui = gui;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(Colors.color(plugin.getLang().getString("only-players")));
+            return true;
+        }
+        player.openInventory(gui.build(player));
+        player.sendMessage(Colors.color(plugin.getLang().getString("opened-gui")));
+        return true;
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/gui/PetsGUI.java
+++ b/LootPets/src/main/java/com/lootpets/gui/PetsGUI.java
@@ -1,0 +1,56 @@
+package com.lootpets.gui;
+
+import com.lootpets.LootPetsPlugin;
+import com.lootpets.service.SlotService;
+import com.lootpets.util.Colors;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+public class PetsGUI {
+
+    private final LootPetsPlugin plugin;
+    private final SlotService slotService;
+
+    public PetsGUI(LootPetsPlugin plugin, SlotService slotService) {
+        this.plugin = plugin;
+        this.slotService = slotService;
+    }
+
+    public Inventory build(Player player) {
+        FileConfiguration cfg = plugin.getConfig();
+        FileConfiguration lang = plugin.getLang();
+        int rows = cfg.getInt("gui.rows");
+        Inventory inv = Bukkit.createInventory(null, rows * 9, Colors.color(cfg.getString("gui.title")));
+
+        List<Integer> active = cfg.getIntegerList("gui.active-slot-indices");
+        int limit = slotService.getMaxSlots(player);
+        ItemStack empty = item(Material.LIME_STAINED_GLASS_PANE, Colors.color(lang.getString("empty-slot-name")));
+        ItemStack locked = item(Material.GRAY_STAINED_GLASS_PANE, Colors.color(lang.getString("locked-slot-name")));
+        for (int i = 0; i < active.size(); i++) {
+            int index = active.get(i);
+            if (i < limit) {
+                inv.setItem(index, empty);
+            } else {
+                inv.setItem(index, locked);
+            }
+        }
+        return inv;
+    }
+
+    private ItemStack item(Material mat, String name) {
+        ItemStack stack = new ItemStack(mat);
+        ItemMeta meta = stack.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(name);
+            stack.setItemMeta(meta);
+        }
+        return stack;
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/service/PetService.java
+++ b/LootPets/src/main/java/com/lootpets/service/PetService.java
@@ -1,0 +1,56 @@
+package com.lootpets.service;
+
+import com.lootpets.LootPetsPlugin;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+public class PetService {
+
+    private final File file;
+    private final YamlConfiguration config;
+
+    public PetService(LootPetsPlugin plugin) {
+        this.file = new File(plugin.getDataFolder(), "pets.yml");
+        this.config = YamlConfiguration.loadConfiguration(file);
+        if (!config.isConfigurationSection("players")) {
+            config.createSection("players");
+            save();
+        }
+    }
+
+    public void ensurePlayer(UUID uuid) {
+        ConfigurationSection players = config.getConfigurationSection("players");
+        if (players == null) {
+            players = config.createSection("players");
+        }
+        if (!players.isConfigurationSection(uuid.toString())) {
+            ConfigurationSection section = players.createSection(uuid.toString());
+            section.set("owned", Collections.emptyList());
+            section.set("active", Collections.emptyList());
+            save();
+        }
+    }
+
+    public List<String> getOwned(UUID uuid) {
+        ConfigurationSection sec = config.getConfigurationSection("players." + uuid);
+        return sec == null ? Collections.emptyList() : sec.getStringList("owned");
+    }
+
+    public List<String> getActive(UUID uuid) {
+        ConfigurationSection sec = config.getConfigurationSection("players." + uuid);
+        return sec == null ? Collections.emptyList() : sec.getStringList("active");
+    }
+
+    private void save() {
+        try {
+            config.save(file);
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/service/RarityRegistry.java
+++ b/LootPets/src/main/java/com/lootpets/service/RarityRegistry.java
@@ -1,0 +1,82 @@
+package com.lootpets.service;
+
+import com.lootpets.LootPetsPlugin;
+import org.bukkit.ChatColor;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RarityRegistry {
+
+    public record Rarity(String id, String displayName, String color) {}
+
+    private final Map<String, Rarity> rarities;
+    private final boolean fallback;
+
+    public RarityRegistry(LootPetsPlugin plugin) {
+        Map<String, Rarity> map = new LinkedHashMap<>();
+        boolean fb = false;
+        try {
+            Class<?> clazz = Class.forName("com.specialitems.leveling.Rarity");
+            Object[] constants = clazz.getEnumConstants();
+            for (Object constant : constants) {
+                Enum<?> e = (Enum<?>) constant;
+                String id = e.name();
+                String name = resolveDisplayName(constant);
+                String color = resolveColor(constant);
+                map.put(id, new Rarity(id, name, color));
+            }
+        } catch (Throwable t) {
+            plugin.getLogger().warning("Failed to import rarities from SpecialItems, using fallback.");
+            map.put("COMMON", new Rarity("COMMON", "Common", "§f"));
+            fb = true;
+        }
+        this.rarities = Collections.unmodifiableMap(map);
+        this.fallback = fb;
+    }
+
+    public Map<String, Rarity> getRarities() {
+        return rarities;
+    }
+
+    public boolean isFallback() {
+        return fallback;
+    }
+
+    public int size() {
+        return rarities.size();
+    }
+
+    private String resolveDisplayName(Object constant) {
+        for (String name : new String[]{"displayName", "getDisplayName", "toString"}) {
+            try {
+                Method m = constant.getClass().getMethod(name);
+                Object val = m.invoke(constant);
+                if (val instanceof String s) {
+                    return s;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return ((Enum<?>) constant).name();
+    }
+
+    private String resolveColor(Object constant) {
+        for (String name : new String[]{"color", "getColor", "chatColor", "getChatColor"}) {
+            try {
+                Method m = constant.getClass().getMethod(name);
+                Object val = m.invoke(constant);
+                if (val instanceof ChatColor cc) {
+                    return "§" + cc.getChar();
+                }
+                if (val instanceof String s) {
+                    return s;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return "§f";
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/service/SlotService.java
+++ b/LootPets/src/main/java/com/lootpets/service/SlotService.java
@@ -1,0 +1,44 @@
+package com.lootpets.service;
+
+import com.lootpets.LootPetsPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class SlotService {
+
+    private final LootPetsPlugin plugin;
+    private final Map<UUID, Integer> cache = new HashMap<>();
+
+    public SlotService(LootPetsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public int getMaxSlots(Player player) {
+        return cache.computeIfAbsent(player.getUniqueId(), id -> computeSlots(player));
+    }
+
+    private int computeSlots(Player player) {
+        int max = plugin.getConfig().getInt("default-slots");
+        String prefix = plugin.getConfig().getString("slot-permission-prefix", "");
+        if (prefix != null && !prefix.isEmpty()) {
+            for (PermissionAttachmentInfo pai : player.getEffectivePermissions()) {
+                String perm = pai.getPermission();
+                if (perm.startsWith(prefix)) {
+                    String num = perm.substring(prefix.length());
+                    try {
+                        int value = Integer.parseInt(num);
+                        if (value > max) {
+                            max = value;
+                        }
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+        }
+        return max;
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/util/Colors.java
+++ b/LootPets/src/main/java/com/lootpets/util/Colors.java
@@ -1,0 +1,15 @@
+package com.lootpets.util;
+
+import org.bukkit.ChatColor;
+
+public final class Colors {
+    private Colors() {}
+
+    public static String color(String input) {
+        return input == null ? "" : ChatColor.translateAlternateColorCodes('&', input);
+    }
+
+    public static String prefix(String prefix, String name) {
+        return color(prefix) + color(name);
+    }
+}

--- a/LootPets/src/main/resources/config.yml
+++ b/LootPets/src/main/resources/config.yml
@@ -1,0 +1,19 @@
+default-slots: 2
+slot-permission-prefix: "lootpets.slots."
+
+gui:
+  title: "&6Pets"
+  rows: 6
+  active-slot-indices:
+    - 0
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+  owned-range:
+    start: 9
+    end: 53

--- a/LootPets/src/main/resources/lang.yml
+++ b/LootPets/src/main/resources/lang.yml
@@ -1,0 +1,4 @@
+only-players: "&cOnly players can use this command."
+opened-gui: "&aOpened your pets GUI."
+empty-slot-name: "&7Empty Slot"
+locked-slot-name: "&8Locked Slot"

--- a/LootPets/src/main/resources/pets.yml
+++ b/LootPets/src/main/resources/pets.yml
@@ -1,0 +1,2 @@
+schema: 1
+players: {}

--- a/LootPets/src/main/resources/plugin.yml
+++ b/LootPets/src/main/resources/plugin.yml
@@ -1,0 +1,13 @@
+name: LootPets
+main: com.lootpets.LootPetsPlugin
+version: 0.1.0
+api-version: '1.21'
+softdepend:
+  - SpecialItems
+commands:
+  pets:
+    description: Open your pets GUI
+    usage: /pets
+permissions:
+  lootpets.admin:
+    default: op


### PR DESCRIPTION
## Summary
- add LootPets module with basic Paper 1.21.4 setup
- implement skeleton services for slots, pets, and rarity reflection
- create GUI command to show placeholder pet slots

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68af58b293bc83259a245679a1ff500b