### PR TITLE
Fix LootPets compile issues and add config-driven shop slot

### DIFF
--- a/LootPets/src/main/java/com/lootpets/gui/PetsGUI.java
+++ b/LootPets/src/main/java/com/lootpets/gui/PetsGUI.java
@@ -190,7 +190,7 @@ public class PetsGUI implements Listener {
         int typeSlot = 48;
         int compareSlot = 49;
         int albumSlot = 50;
-        int shopSlot = 51;
+        int shopSlot = cfg.getInt("shards.shop.gui.slot", -1);
         if (sortingEnabled) {
             String mode = state.sortIndex >= 0 && state.sortIndex < cfg.getStringList("gui.sorting.modes").size()
                     ? cfg.getStringList("gui.sorting.modes").get(state.sortIndex)
@@ -214,8 +214,8 @@ public class PetsGUI implements Listener {
         if (cfg.getBoolean("album.open_from_pets_gui", true) && cfg.getBoolean("gui.features.album_enabled", true)) {
             inv.setItem(albumSlot, item(Material.CHEST, Colors.color(lang.getString("album-button"))));
         }
-        if (plugin.getConfig().getBoolean("shards.shop.gui.open_from_pets_gui", true)
-                && plugin.getConfig().getBoolean("shards.shop.enabled", true)) {
+        if (cfg.getBoolean("shards.shop.gui.open_from_pets_gui", true)
+                && cfg.getBoolean("shards.shop.enabled", true) && shopSlot >= 0) {
             inv.setItem(shopSlot, item(Material.EMERALD, Colors.color(lang.getString("shop-button"))));
         }
 
@@ -245,6 +245,7 @@ public class PetsGUI implements Listener {
         int typeSlot = 48;
         int compareSlot = 49;
         int albumSlot = 50;
+        int shopSlot = cfg.getInt("shards.shop.gui.slot", -1);
         int slot = event.getRawSlot();
 
         if (slot == prevSlot) {
@@ -293,7 +294,7 @@ public class PetsGUI implements Listener {
             plugin.getAlbumGUI().open(player);
             return;
         }
-        if (slot == shopSlot && plugin.getShardShopGUI() != null) {
+        if (shopSlot >= 0 && slot == shopSlot && plugin.getShardShopGUI() != null) {
             plugin.getShardShopGUI().open(player);
             return;
         }

--- a/LootPets/src/main/java/com/lootpets/gui/ShardShopGUI.java
+++ b/LootPets/src/main/java/com/lootpets/gui/ShardShopGUI.java
@@ -45,16 +45,19 @@ public class ShardShopGUI implements Listener {
         int rows = cfg == null ? 6 : cfg.getInt("rows", 6);
         String title = cfg == null ? "Shard Shop" : cfg.getString("title", "Shard Shop");
         Inventory inv = Bukkit.createInventory(null, rows * 9, Colors.color(title));
-        List<Map<?, ?>> list = plugin.getConfig().getMapList("shards.shop.items");
+        @SuppressWarnings("unchecked")
+        List<Map<String, ?>> list = (List<Map<String, ?>>) (List<?>) plugin.getConfig().getMapList("shards.shop.items");
         Map<Integer, ShopItem> map = new HashMap<>();
         int slot = 0;
         int shards = petService.getShards(player.getUniqueId());
         String today = LocalDate.now(ZoneOffset.UTC).toString();
-        for (Map<?, ?> m : list) {
+        for (Map<String, ?> m : list) {
             String id = String.valueOf(m.get("id"));
             String type = String.valueOf(m.get("type"));
-            int cost = ((Number) m.getOrDefault("cost", 0)).intValue();
-            int xp = ((Number) m.getOrDefault("xp_amount", 0)).intValue();
+            Object co = m.get("cost");
+            int cost = (co instanceof Number) ? ((Number) co).intValue() : 0;
+            Object xo = m.get("xp_amount");
+            int xp = (xo instanceof Number) ? ((Number) xo).intValue() : 0;
             String style = m.get("style") == null ? null : String.valueOf(m.get("style"));
             ShopItem item = new ShopItem(id, type, cost, xp, style);
             ItemStack icon = iconFor(item, shards, player, today);

--- a/LootPets/src/main/java/com/lootpets/model/OwnedPetState.java
+++ b/LootPets/src/main/java/com/lootpets/model/OwnedPetState.java
@@ -1,11 +1,87 @@
 package com.lootpets.model;
 
-public record OwnedPetState(
-        String rarity,
-        int level,
-        int stars,
-        int evolveProgress,
-        int xp,
-        String suffix
-) {
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Mutable-free data holder for a player's progress on a specific pet.
+ */
+public class OwnedPetState {
+    private final String rarityId;
+    private final int level;
+    private final int xp;
+    private final int stars;
+    private final int evolveProgress;
+    @Nullable
+    private final String suffix;
+
+    public OwnedPetState(String rarityId, int level, int xp, int stars, int evolveProgress, @Nullable String suffix) {
+        this.rarityId = rarityId;
+        this.level = level;
+        this.xp = xp;
+        this.stars = stars;
+        this.evolveProgress = evolveProgress;
+        this.suffix = suffix;
+    }
+
+    public String getRarityId() {
+        return rarityId;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public int getXp() {
+        return xp;
+    }
+
+    public int getStars() {
+        return stars;
+    }
+
+    public int getEvolveProgress() {
+        return evolveProgress;
+    }
+
+    @Nullable
+    public String getSuffix() {
+        return suffix;
+    }
+
+    // Backwards compatibility helpers
+    public String rarity() {
+        return rarityId;
+    }
+
+    public int level() {
+        return level;
+    }
+
+    public int xp() {
+        return xp;
+    }
+
+    public int stars() {
+        return stars;
+    }
+
+    public int evolveProgress() {
+        return evolveProgress;
+    }
+
+    public String suffix() {
+        return suffix;
+    }
+
+    @Override
+    public String toString() {
+        return "OwnedPetState{" +
+                "rarityId='" + rarityId + '\'' +
+                ", level=" + level +
+                ", xp=" + xp +
+                ", stars=" + stars +
+                ", evolveProgress=" + evolveProgress +
+                ", suffix='" + suffix + '\'' +
+                '}';
+    }
 }

--- a/LootPets/src/main/java/com/lootpets/model/PetDefinition.java
+++ b/LootPets/src/main/java/com/lootpets/model/PetDefinition.java
@@ -2,7 +2,10 @@ package com.lootpets.model;
 
 import org.bukkit.Material;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.OptionalInt;
 
 public record PetDefinition(
         String id,
@@ -10,4 +13,22 @@ public record PetDefinition(
         Material iconMaterial,
         Integer iconCustomModelData,
         Map<String, Double> weights
-) {}
+) {
+    @Override
+    public Material iconMaterial() {
+        return iconMaterial;
+    }
+
+    public OptionalInt iconCmd() {
+        return iconCustomModelData == null ? OptionalInt.empty() : OptionalInt.of(iconCustomModelData);
+    }
+
+    public Map<String, Object> icon() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("material", iconMaterial.name());
+        if (iconCustomModelData != null) {
+            map.put("custom_model_data", iconCustomModelData);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+}

--- a/LootPets/src/main/java/com/lootpets/service/CrossServerService.java
+++ b/LootPets/src/main/java/com/lootpets/service/CrossServerService.java
@@ -51,7 +51,7 @@ public class CrossServerService {
             hbi = hbSec != null ? hbSec.getInt("interval_seconds", 15) : 15;
             sid = hbSec != null ? hbSec.getString("server_id", "AUTO") : "AUTO";
             if ("AUTO".equalsIgnoreCase(sid)) {
-                sid = plugin.getServer().getServerName() + "-" + UUID.randomUUID();
+                sid = plugin.getServer().getName() + "-" + UUID.randomUUID();
             }
             active = sec.getBoolean("enabled", false) && sqlTmp != null && sqlTmp.getProvider() != SqlStorageAdapter.Provider.SQLITE;
         }
@@ -83,7 +83,7 @@ public class CrossServerService {
         long ticks = hbInterval * 20L;
         hbTask = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
             try {
-                storage.heartbeat(serverId, plugin.getServer().getServerName(), bootTime);
+                storage.heartbeat(serverId, plugin.getServer().getName(), bootTime);
             } catch (Exception ignored) {}
         }, ticks, ticks).getTaskId();
     }

--- a/LootPets/src/main/java/com/lootpets/service/PetService.java
+++ b/LootPets/src/main/java/com/lootpets/service/PetService.java
@@ -229,7 +229,7 @@ public class PetService implements Listener {
                 capped = true;
             }
         }
-        OwnedPetState ns = new OwnedPetState(st.rarity(), st.level(), stars, progress, st.xp(), st.suffix());
+        OwnedPetState ns = new OwnedPetState(st.rarity(), st.level(), st.xp(), stars, progress, st.suffix());
         putOwned(data, petId, ns);
         markDirty(uuid);
         if (starUp) notifyChange(uuid);
@@ -293,7 +293,7 @@ public class PetService implements Listener {
                     xp = 0;
                 }
             }
-            OwnedPetState ns = new OwnedPetState(st.rarity(), level, stars, st.evolveProgress(), xp, st.suffix());
+            OwnedPetState ns = new OwnedPetState(st.rarity(), level, xp, stars, st.evolveProgress(), st.suffix());
             putOwned(data, petId, ns);
             if (level != oldLevel) levelChanged = true;
             if (plugin.getTraceService() != null && level != oldLevel) {
@@ -315,7 +315,7 @@ public class PetService implements Listener {
         if (st == null) return false;
         int cap = baseCap + extraPerStar * st.stars();
         int clamped = Math.max(0, Math.min(level, cap));
-        OwnedPetState ns = new OwnedPetState(st.rarity(), clamped, st.stars(), st.evolveProgress(), 0, st.suffix());
+        OwnedPetState ns = new OwnedPetState(st.rarity(), clamped, 0, st.stars(), st.evolveProgress(), st.suffix());
         putOwned(data, petId, ns);
         markDirty(uuid);
         notifyChange(uuid);
@@ -326,7 +326,7 @@ public class PetService implements Listener {
         PlayerData data = load(uuid);
         OwnedPetState st = owned(data, petId);
         if (st == null) return false;
-        OwnedPetState ns = new OwnedPetState(st.rarity(), st.level(), stars, st.evolveProgress(), st.xp(), st.suffix());
+        OwnedPetState ns = new OwnedPetState(st.rarity(), st.level(), st.xp(), stars, st.evolveProgress(), st.suffix());
         putOwned(data, petId, ns);
         markDirty(uuid);
         notifyChange(uuid);
@@ -352,7 +352,7 @@ public class PetService implements Listener {
             }
             levelChanged = true;
         }
-        OwnedPetState ns = new OwnedPetState(st.rarity(), level, stars, st.evolveProgress(), xp, st.suffix());
+        OwnedPetState ns = new OwnedPetState(st.rarity(), level, xp, stars, st.evolveProgress(), st.suffix());
         putOwned(data, petId, ns);
         markDirty(uuid);
         if (levelChanged) notifyChange(uuid);
@@ -418,7 +418,7 @@ public class PetService implements Listener {
         PlayerData data = load(uuid);
         OwnedPetState st = owned(data, petId);
         if (st == null) return;
-        putOwned(data, petId, new OwnedPetState(st.rarity(), st.level(), st.stars(), st.evolveProgress(), st.xp(), suffix));
+        putOwned(data, petId, new OwnedPetState(st.rarity(), st.level(), st.xp(), st.stars(), st.evolveProgress(), suffix));
         markDirty(uuid);
     }
 

--- a/LootPets/src/main/java/com/lootpets/storage/SqlStorageAdapter.java
+++ b/LootPets/src/main/java/com/lootpets/storage/SqlStorageAdapter.java
@@ -79,7 +79,7 @@ public class SqlStorageAdapter implements StorageAdapter {
                     int stars = rs.getInt(5);
                     int prog = rs.getInt(6);
                     String suffix = rs.getString(7);
-                    data.owned.put(pid, new OwnedPetState(rid, level, stars, prog, xp, suffix));
+                    data.owned.put(pid, new OwnedPetState(rid, level, xp, stars, prog, suffix));
                 }
             }
         }

--- a/LootPets/src/main/java/com/lootpets/storage/YamlStorageAdapter.java
+++ b/LootPets/src/main/java/com/lootpets/storage/YamlStorageAdapter.java
@@ -45,7 +45,7 @@ public class YamlStorageAdapter implements StorageAdapter {
                 int progress = ps.getInt("evolve_progress", 0);
                 int xp = ps.getInt("xp", 0);
                 String suffix = ps.getString("suffix", null);
-                data.owned.put(id, new OwnedPetState(rarity, level, stars, progress, xp, suffix));
+                data.owned.put(id, new OwnedPetState(rarity, level, xp, stars, progress, suffix));
             }
         }
         data.active.addAll(sec.getStringList("active"));

--- a/LootPets/src/main/resources/config.yml
+++ b/LootPets/src/main/resources/config.yml
@@ -173,6 +173,7 @@ shards:
       title: "&d&lShard Shop"
       rows: 6
       open_from_pets_gui: true
+      slot: 51
     items:
       - id: "add_evolve_1"
         type: "EVOLVE_PROGRESS"


### PR DESCRIPTION
## Summary
- add OwnedPetState data class and wire PetService to return typed states
- expose icon material/cmd metadata in PetDefinition
- pull shard shop slot from config and harden ShardShopGUI map handling
- fix cross-server service API calls

## Testing
- `gradle clean jar` *(fails: Could not resolve com.github.MilkBowl:VaultAPI:1.7.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b035883e008325a7ea43256ebdb94f