### PR TITLE
Use amethyst shards for pet GUI items

### DIFF
--- a/LootPets/src/main/java/com/lootpets/gui/PetsGUI.java
+++ b/LootPets/src/main/java/com/lootpets/gui/PetsGUI.java
@@ -203,7 +203,7 @@ public class PetsGUI implements Listener {
         }
         if (filtersEnabled && cfg.getBoolean("gui.filters.type_filter", true)) {
             String val = state.typeIndex == 0 ? "ALL" : types[state.typeIndex - 1].name().replace("EARNINGS_", "");
-            inv.setItem(typeSlot, item(Material.PAPER, Colors.color(lang.getString("filter-label").replace("%value%", val))));
+            inv.setItem(typeSlot, item(Material.AMETHYST_SHARD, Colors.color(lang.getString("filter-label").replace("%value%", val))));
         }
         if (cfg.getBoolean("gui.features.compare_enabled", true)) {
             String label = lang.getString("compare-button")

--- a/LootPets/src/main/java/com/lootpets/gui/ShardShopGUI.java
+++ b/LootPets/src/main/java/com/lootpets/gui/ShardShopGUI.java
@@ -76,7 +76,7 @@ public class ShardShopGUI implements Listener {
             case "ADD_XP" -> mat = Material.EXPERIENCE_BOTTLE;
             case "RENAME_TOKEN" -> mat = Material.NAME_TAG;
             case "ALBUM_FRAME" -> mat = Material.PAINTING;
-            default -> mat = Material.PAPER;
+            default -> mat = Material.AMETHYST_SHARD;
         }
         ItemStack stack = new ItemStack(mat);
         ItemMeta meta = stack.getItemMeta();


### PR DESCRIPTION
## Summary
- Replace paper with amethyst shards for the pet type filter
- Use amethyst shards as default icon in the shard shop

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68b183fa95c08325b844a08f974952d4