### PR TITLE
Keep SpecialItems level and XP lore updated

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
+++ b/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
@@ -11,6 +11,7 @@ import com.specialitems.listeners.BinListener;
 import com.specialitems.listeners.JoinFixListener;
 import com.specialitems.listeners.InventorySanityListener;
 import com.specialitems.listeners.GiveInterceptListener;
+import com.specialitems.listeners.LoreUpdateListener;
 import com.specialitems.util.Configs;
 import com.specialitems.util.Log;
 import com.specialitems.util.TemplateItems;
@@ -116,6 +117,7 @@ public class SpecialItemsPlugin extends JavaPlugin {
         // --- Leveling system (NEW) ---
         this.leveling = new LevelingService(this);
         getServer().getPluginManager().registerEvents(new LevelingListener(leveling), this);
+        getServer().getPluginManager().registerEvents(new LoreUpdateListener(leveling), this);
         getServer().getServicesManager().register(SpecialItemsApi.class, new SpecialItemsBridge(leveling), this, ServicePriority.Normal);
 
         // Ticker (kept from your original)

--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
@@ -104,6 +104,9 @@ public class LevelingService {
             meta.addEnchant(Enchantment.UNBREAKING, 1, true);
         }
         item.setItemMeta(meta);
+        try {
+            com.specialitems.util.LoreRenderer.updateItemLore(item);
+        } catch (Throwable ignored) {}
     }
 
     // ---------------------------------------------------------------------
@@ -169,6 +172,9 @@ public class LevelingService {
         pdc.set(keys.LEVEL, PersistentDataType.INTEGER, level);
         pdc.set(keys.XP, PersistentDataType.INTEGER, xp);
         item.setItemMeta(meta);
+        try {
+            com.specialitems.util.LoreRenderer.updateItemLore(item);
+        } catch (Throwable ignored) {}
         if (leveled && player != null) {
             String itemName = meta.hasDisplayName() ? ChatColor.stripColor(meta.getDisplayName()) : item.getType().name();
             String msg = ChatColor.GOLD + itemName + ChatColor.GREEN + " reached level " + level;

--- a/SpecialItems/src/main/java/com/specialitems/listeners/LoreUpdateListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/LoreUpdateListener.java
@@ -1,0 +1,82 @@
+package com.specialitems.listeners;
+
+import com.specialitems.leveling.LevelingService;
+import com.specialitems.util.LoreRenderer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/** Refreshes lore displays for special items on common inventory interactions. */
+public class LoreUpdateListener implements Listener {
+    private final LevelingService svc;
+
+    public LoreUpdateListener(LevelingService svc) {
+        this.svc = svc;
+    }
+
+    private void refreshSlot(Inventory inv, int slot, ItemStack item) {
+        if (item == null) return;
+        if (!svc.isSpecialItem(item)) return;
+        LoreRenderer.updateItemLore(item);
+        inv.setItem(slot, item);
+    }
+
+    @EventHandler
+    public void onOpen(InventoryOpenEvent e) {
+        Inventory top = e.getInventory();
+        ItemStack[] items = top.getContents();
+        for (int i = 0; i < items.length; i++) {
+            refreshSlot(top, i, items[i]);
+        }
+        Inventory bottom = e.getPlayer().getInventory();
+        ItemStack[] bItems = bottom.getContents();
+        for (int i = 0; i < bItems.length; i++) {
+            refreshSlot(bottom, i, bItems[i]);
+        }
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        ItemStack current = e.getCurrentItem();
+        if (current != null && svc.isSpecialItem(current)) {
+            LoreRenderer.updateItemLore(current);
+            e.setCurrentItem(current);
+        }
+        ItemStack cursor = e.getCursor();
+        if (cursor != null && svc.isSpecialItem(cursor)) {
+            LoreRenderer.updateItemLore(cursor);
+            e.setCursor(cursor);
+        }
+    }
+
+    @EventHandler
+    public void onHeld(PlayerItemHeldEvent e) {
+        Player p = e.getPlayer();
+        int slot = e.getNewSlot();
+        ItemStack item = p.getInventory().getItem(slot);
+        if (item != null && svc.isSpecialItem(item)) {
+            LoreRenderer.updateItemLore(item);
+            p.getInventory().setItem(slot, item);
+        }
+    }
+
+    @EventHandler
+    public void onSwap(PlayerSwapHandItemsEvent e) {
+        ItemStack main = e.getMainHandItem();
+        if (main != null && svc.isSpecialItem(main)) {
+            LoreRenderer.updateItemLore(main);
+            e.setMainHandItem(main);
+        }
+        ItemStack off = e.getOffHandItem();
+        if (off != null && svc.isSpecialItem(off)) {
+            LoreRenderer.updateItemLore(off);
+            e.setOffHandItem(off);
+        }
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/util/GuiItemUtil.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/GuiItemUtil.java
@@ -3,8 +3,6 @@ package com.specialitems.util;
 import com.specialitems.SpecialItemsPlugin;
 import com.specialitems.effects.CustomEffect;
 import com.specialitems.effects.Effects;
-import com.specialitems.leveling.LevelMath;
-import com.specialitems.leveling.ToolClass;
 import com.specialitems.leveling.Keys;
 import com.specialitems.leveling.Rarity;
 import com.specialitems.leveling.RarityUtil;
@@ -52,24 +50,28 @@ public final class GuiItemUtil {
         boolean special = svc.isSpecialItem(it) || hasSpecialPdc(it);
         if (!special) return null;
 
-        int lvl = svc.getLevel(it);
-        double xp = svc.getXp(it);
-        double need = LevelMath.neededXpFor(lvl);
         Rarity rarity = RarityUtil.get(it, new Keys(plugin));
 
         ItemStack display = it.clone();
+        com.specialitems.util.LoreRenderer.updateItemLore(display);
         ItemMeta meta = display.getItemMeta();
         if (meta != null) {
             try { meta.removeItemFlags(ItemFlag.values()); } catch (Throwable ignored) {}
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS, ItemFlag.HIDE_UNBREAKABLE);
-            List<String> lore = new ArrayList<>();
-            lore.add(ChatColor.GOLD + "Level: " + ChatColor.YELLOW + lvl);
-            lore.add(ChatColor.GOLD + "XP: " + ChatColor.YELLOW + String.format("%.1f", xp) + ChatColor.GRAY + " / " + ChatColor.YELLOW + String.format("%.1f", need));
-            lore.add(ChatColor.GOLD + "Rarity: " + rarity.displayName());
-            if (svc.detectToolClass(it) == ToolClass.HOE) {
-                double by = svc.getBonusYieldPct(it);
-                lore.add(ChatColor.GOLD + "Bonus Yield: " + ChatColor.YELLOW + String.format("%.0f%%", by));
+            List<String> lore = meta.getLore();
+            if (lore == null) lore = new ArrayList<>();
+
+            String harvest = null;
+            for (int i = 0; i < lore.size(); i++) {
+                String s = ChatColor.stripColor(lore.get(i));
+                if (s.startsWith("Harvest Bonus:")) {
+                    harvest = lore.remove(i);
+                    break;
+                }
             }
+
+            lore.add(ChatColor.GOLD + "Rarity: " + rarity.displayName());
+            if (harvest != null) lore.add(harvest);
 
             Map<Enchantment, Integer> enchants = it.getEnchantments();
             if (!enchants.isEmpty()) {

--- a/SpecialItems/src/main/java/com/specialitems/util/LoreRenderer.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/LoreRenderer.java
@@ -1,0 +1,87 @@
+package com.specialitems.util;
+
+import com.specialitems.SpecialItemsPlugin;
+import com.specialitems.leveling.LevelMath;
+import com.specialitems.leveling.LevelingService;
+import com.specialitems.leveling.ToolClass;
+import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Utility to keep item lore in sync with level and XP. */
+public final class LoreRenderer {
+    private LoreRenderer() {}
+
+    public static boolean updateItemLore(ItemStack item) {
+        LevelingService svc = SpecialItemsPlugin.getInstance().leveling();
+        if (item == null || svc == null || item.getType().isAir()) return false;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+
+        int level = svc.getLevel(item);
+        int xp = svc.getXp(item);
+        int needed = (int) LevelMath.neededXpFor(level);
+        boolean isHoe = svc.detectToolClass(item) == ToolClass.HOE;
+        double bonus = isHoe ? svc.getBonusYieldPct(item) : 0.0;
+
+        List<String> lore = meta.getLore();
+        if (lore == null) lore = new ArrayList<>();
+
+        int lvlIdx = indexOfPrefix(lore, "Level:");
+        int xpIdx = indexOfPrefix(lore, "XP:");
+        int bonusIdx = indexOfPrefix(lore, "Harvest Bonus:");
+
+        String lvlLine = ChatColor.GOLD + "Level: " + ChatColor.YELLOW + level;
+        String xpLine = ChatColor.GOLD + "XP: " + ChatColor.YELLOW + String.format("%.1f", (double) xp) + ChatColor.GRAY +
+                " / " + ChatColor.YELLOW + String.format("%.1f", (double) needed);
+        String bonusLine = ChatColor.GOLD + "Harvest Bonus: " + ChatColor.YELLOW + String.format("%.0f%%", bonus);
+
+        boolean changed = false;
+        if (lvlIdx >= 0) {
+            if (!lore.get(lvlIdx).equals(lvlLine)) { lore.set(lvlIdx, lvlLine); changed = true; }
+        } else {
+            lore.add(0, lvlLine);
+            changed = true;
+            xpIdx++;
+            bonusIdx++;
+        }
+
+        if (xpIdx >= 0) {
+            if (!lore.get(xpIdx).equals(xpLine)) { lore.set(xpIdx, xpLine); changed = true; }
+        } else {
+            int insert = Math.min(lore.size(), (lvlIdx >= 0 ? lvlIdx + 1 : lore.size()));
+            lore.add(insert, xpLine);
+            changed = true;
+            bonusIdx++;
+        }
+
+        if (isHoe) {
+            if (bonusIdx >= 0) {
+                if (!lore.get(bonusIdx).equals(bonusLine)) { lore.set(bonusIdx, bonusLine); changed = true; }
+            } else {
+                int insert = Math.min(lore.size(), Math.max(lvlIdx, xpIdx) + 1);
+                lore.add(insert, bonusLine);
+                changed = true;
+            }
+        } else if (bonusIdx >= 0) {
+            lore.remove(bonusIdx);
+            changed = true;
+        }
+
+        if (changed) {
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        }
+        return changed;
+    }
+
+    private static int indexOfPrefix(List<String> lore, String prefix) {
+        for (int i = 0; i < lore.size(); i++) {
+            if (ChatColor.stripColor(lore.get(i)).startsWith(prefix)) return i;
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize Level/XP/Harvest Bonus formatting in `LoreRenderer`
- refresh item lore after XP updates and inventory interactions
- ensure GUI displays reuse consistent lore

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68b2e1eb4370832588fb7fa5a3d2ef7a