### PR TITLE
Add adventure-based lore rendering for SpecialItems

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
+++ b/SpecialItems/src/main/java/com/specialitems/leveling/LevelingService.java
@@ -1,6 +1,7 @@
 package com.specialitems.leveling;
 
 import com.specialitems.util.TemplateItems;
+import com.specialitems.util.ItemLoreService;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -30,6 +31,7 @@ public class LevelingService {
 
     private final Keys keys;
     private final Random random = new Random();
+    private final JavaPlugin plugin;
 
     private static final int XP_PER_ACTION = 1;
 
@@ -52,6 +54,7 @@ public class LevelingService {
     );
 
     public LevelingService(JavaPlugin plugin) {
+        this.plugin = plugin;
         this.keys = new Keys(plugin);
     }
 
@@ -105,7 +108,7 @@ public class LevelingService {
         }
         item.setItemMeta(meta);
         try {
-            com.specialitems.util.LoreRenderer.updateItemLore(item);
+            ItemLoreService.renderLore(item, plugin);
         } catch (Throwable ignored) {}
     }
 
@@ -173,7 +176,7 @@ public class LevelingService {
         pdc.set(keys.XP, PersistentDataType.INTEGER, xp);
         item.setItemMeta(meta);
         try {
-            com.specialitems.util.LoreRenderer.updateItemLore(item);
+            ItemLoreService.renderLore(item, plugin);
         } catch (Throwable ignored) {}
         if (leveled && player != null) {
             String itemName = meta.hasDisplayName() ? ChatColor.stripColor(meta.getDisplayName()) : item.getType().name();

--- a/SpecialItems/src/main/java/com/specialitems/listeners/LoreUpdateListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/LoreUpdateListener.java
@@ -1,7 +1,8 @@
 package com.specialitems.listeners;
 
 import com.specialitems.leveling.LevelingService;
-import com.specialitems.util.LoreRenderer;
+import com.specialitems.util.ItemLoreService;
+import com.specialitems.SpecialItemsPlugin;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -23,7 +24,7 @@ public class LoreUpdateListener implements Listener {
     private void refreshSlot(Inventory inv, int slot, ItemStack item) {
         if (item == null) return;
         if (!svc.isSpecialItem(item)) return;
-        LoreRenderer.updateItemLore(item);
+        ItemLoreService.renderLore(item, SpecialItemsPlugin.getInstance());
         inv.setItem(slot, item);
     }
 
@@ -45,12 +46,12 @@ public class LoreUpdateListener implements Listener {
     public void onClick(InventoryClickEvent e) {
         ItemStack current = e.getCurrentItem();
         if (current != null && svc.isSpecialItem(current)) {
-            LoreRenderer.updateItemLore(current);
+            ItemLoreService.renderLore(current, SpecialItemsPlugin.getInstance());
             e.setCurrentItem(current);
         }
         ItemStack cursor = e.getCursor();
         if (cursor != null && svc.isSpecialItem(cursor)) {
-            LoreRenderer.updateItemLore(cursor);
+            ItemLoreService.renderLore(cursor, SpecialItemsPlugin.getInstance());
             e.setCursor(cursor);
         }
     }
@@ -61,7 +62,7 @@ public class LoreUpdateListener implements Listener {
         int slot = e.getNewSlot();
         ItemStack item = p.getInventory().getItem(slot);
         if (item != null && svc.isSpecialItem(item)) {
-            LoreRenderer.updateItemLore(item);
+            ItemLoreService.renderLore(item, SpecialItemsPlugin.getInstance());
             p.getInventory().setItem(slot, item);
         }
     }
@@ -70,12 +71,12 @@ public class LoreUpdateListener implements Listener {
     public void onSwap(PlayerSwapHandItemsEvent e) {
         ItemStack main = e.getMainHandItem();
         if (main != null && svc.isSpecialItem(main)) {
-            LoreRenderer.updateItemLore(main);
+            ItemLoreService.renderLore(main, SpecialItemsPlugin.getInstance());
             e.setMainHandItem(main);
         }
         ItemStack off = e.getOffHandItem();
         if (off != null && svc.isSpecialItem(off)) {
-            LoreRenderer.updateItemLore(off);
+            ItemLoreService.renderLore(off, SpecialItemsPlugin.getInstance());
             e.setOffHandItem(off);
         }
     }

--- a/SpecialItems/src/main/java/com/specialitems/util/GuiItemUtil.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/GuiItemUtil.java
@@ -53,7 +53,7 @@ public final class GuiItemUtil {
         Rarity rarity = RarityUtil.get(it, new Keys(plugin));
 
         ItemStack display = it.clone();
-        com.specialitems.util.LoreRenderer.updateItemLore(display);
+        ItemLoreService.renderLore(display, plugin);
         ItemMeta meta = display.getItemMeta();
         if (meta != null) {
             try { meta.removeItemFlags(ItemFlag.values()); } catch (Throwable ignored) {}

--- a/SpecialItems/src/main/java/com/specialitems/util/ItemLoreService.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/ItemLoreService.java
@@ -1,0 +1,81 @@
+package com.specialitems.util;
+
+import com.specialitems.leveling.Keys;
+import com.specialitems.leveling.LevelMath;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/** Service for rendering level/XP lore lines on special items. */
+public final class ItemLoreService {
+    private ItemLoreService() {}
+
+    public static void renderLore(ItemStack item, Plugin plugin) {
+        if (item == null || plugin == null || item.getType().isAir()) return;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return;
+
+        Keys keys = new Keys(plugin);
+        PersistentDataContainer pdc = meta.getPersistentDataContainer();
+        if (pdc == null || !pdc.has(keys.SI_ID, PersistentDataType.STRING)) {
+            return; // not a special item
+        }
+
+        Integer lvl = pdc.get(keys.LEVEL, PersistentDataType.INTEGER);
+        int level = (lvl == null ? 1 : lvl);
+        Integer xpVal = pdc.get(keys.XP, PersistentDataType.INTEGER);
+        int xp = (xpVal == null ? 0 : xpVal);
+        int req = (int) LevelMath.neededXpFor(level);
+
+        List<Component> lore = meta.lore();
+        if (lore == null) lore = new ArrayList<>();
+
+        PlainTextComponentSerializer plain = PlainTextComponentSerializer.plainText();
+        Iterator<Component> it = lore.iterator();
+        while (it.hasNext()) {
+            String text = plain.serialize(it.next());
+            if (text.startsWith("Level:") || text.startsWith("XP:")) {
+                it.remove();
+            }
+        }
+
+        double ratio = req > 0 ? (double) xp / (double) req : 0.0;
+        int filled = (int) Math.round(Math.max(0.0, Math.min(1.0, ratio)) * 10.0);
+        StringBuilder bar = new StringBuilder(10);
+        for (int i = 0; i < filled; i++) bar.append('■');
+        for (int i = filled; i < 10; i++) bar.append('□');
+
+        Component levelLine = Component.text("Level: ", NamedTextColor.GRAY)
+                .append(Component.text(level, NamedTextColor.AQUA));
+        Component xpLine = Component.text("XP: ", NamedTextColor.GRAY)
+                .append(Component.text(xp + "/" + req + " ", NamedTextColor.AQUA))
+                .append(Component.text("[", NamedTextColor.DARK_GRAY))
+                .append(Component.text(bar.toString(), NamedTextColor.AQUA))
+                .append(Component.text("]", NamedTextColor.DARK_GRAY));
+
+        lore.add(0, levelLine);
+        lore.add(1, xpLine);
+        meta.lore(lore);
+
+        meta.addItemFlags(
+                ItemFlag.HIDE_ENCHANTS,
+                ItemFlag.HIDE_ATTRIBUTES,
+                ItemFlag.HIDE_UNBREAKABLE,
+                ItemFlag.HIDE_ADDITIONAL_TOOLTIP,
+                ItemFlag.HIDE_ARMOR_TRIM
+        );
+
+        item.setItemMeta(meta);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce ItemLoreService rendering level and XP lore with progress bar
- Refresh lore whenever XP changes or inventory actions occur
- Hide enchantment/attribute lines with item flags

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68b6f444022c8325858160fb4a88a0cb