### PR TITLE
Enhance SpecialItems lore rendering

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/listeners/LoreUpdateListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/LoreUpdateListener.java
@@ -1,5 +1,6 @@
 package com.specialitems.listeners;
 
+import com.specialitems.leveling.Keys;
 import com.specialitems.leveling.LevelingService;
 import com.specialitems.util.ItemLoreService;
 import com.specialitems.SpecialItemsPlugin;
@@ -12,18 +13,25 @@ import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
 
 /** Refreshes lore displays for special items on common inventory interactions. */
 public class LoreUpdateListener implements Listener {
-    private final LevelingService svc;
+    private final Keys keys;
 
     public LoreUpdateListener(LevelingService svc) {
-        this.svc = svc;
+        this.keys = new Keys(SpecialItemsPlugin.getInstance());
+    }
+
+    private boolean isSpecial(ItemStack item) {
+        if (item == null || item.getType().isAir()) return false;
+        ItemMeta meta = item.getItemMeta();
+        return meta != null && meta.getPersistentDataContainer().has(keys.SI_ID, PersistentDataType.STRING);
     }
 
     private void refreshSlot(Inventory inv, int slot, ItemStack item) {
-        if (item == null) return;
-        if (!svc.isSpecialItem(item)) return;
+        if (!isSpecial(item)) return;
         ItemLoreService.renderLore(item, SpecialItemsPlugin.getInstance());
         inv.setItem(slot, item);
     }
@@ -45,12 +53,12 @@ public class LoreUpdateListener implements Listener {
     @EventHandler
     public void onClick(InventoryClickEvent e) {
         ItemStack current = e.getCurrentItem();
-        if (current != null && svc.isSpecialItem(current)) {
+        if (isSpecial(current)) {
             ItemLoreService.renderLore(current, SpecialItemsPlugin.getInstance());
             e.setCurrentItem(current);
         }
         ItemStack cursor = e.getCursor();
-        if (cursor != null && svc.isSpecialItem(cursor)) {
+        if (isSpecial(cursor)) {
             ItemLoreService.renderLore(cursor, SpecialItemsPlugin.getInstance());
             e.setCursor(cursor);
         }
@@ -61,7 +69,7 @@ public class LoreUpdateListener implements Listener {
         Player p = e.getPlayer();
         int slot = e.getNewSlot();
         ItemStack item = p.getInventory().getItem(slot);
-        if (item != null && svc.isSpecialItem(item)) {
+        if (isSpecial(item)) {
             ItemLoreService.renderLore(item, SpecialItemsPlugin.getInstance());
             p.getInventory().setItem(slot, item);
         }
@@ -70,12 +78,12 @@ public class LoreUpdateListener implements Listener {
     @EventHandler
     public void onSwap(PlayerSwapHandItemsEvent e) {
         ItemStack main = e.getMainHandItem();
-        if (main != null && svc.isSpecialItem(main)) {
+        if (isSpecial(main)) {
             ItemLoreService.renderLore(main, SpecialItemsPlugin.getInstance());
             e.setMainHandItem(main);
         }
         ItemStack off = e.getOffHandItem();
-        if (off != null && svc.isSpecialItem(off)) {
+        if (isSpecial(off)) {
             ItemLoreService.renderLore(off, SpecialItemsPlugin.getInstance());
             e.setOffHandItem(off);
         }

--- a/SpecialItems/src/main/java/com/specialitems/util/ItemLoreService.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/ItemLoreService.java
@@ -2,8 +2,10 @@ package com.specialitems.util;
 
 import com.specialitems.leveling.Keys;
 import com.specialitems.leveling.LevelMath;
+import com.specialitems.leveling.Rarity;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -13,7 +15,6 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /** Service for rendering level/XP lore lines on special items. */
@@ -31,51 +32,87 @@ public final class ItemLoreService {
             return; // not a special item
         }
 
-        Integer lvl = pdc.get(keys.LEVEL, PersistentDataType.INTEGER);
-        int level = (lvl == null ? 1 : lvl);
-        Integer xpVal = pdc.get(keys.XP, PersistentDataType.INTEGER);
-        int xp = (xpVal == null ? 0 : xpVal);
-        int req = (int) LevelMath.neededXpFor(level);
+        int level = pdc.getOrDefault(keys.LEVEL, PersistentDataType.INTEGER, 1);
+        int xp = pdc.getOrDefault(keys.XP, PersistentDataType.INTEGER, 0);
+        int req = Math.max(1, (int) LevelMath.neededXpFor(level));
+        String rarityRaw = pdc.get(keys.RARITY, PersistentDataType.STRING);
+        Rarity rarity = Rarity.fromString(rarityRaw);
 
-        List<Component> lore = meta.lore();
-        if (lore == null) lore = new ArrayList<>();
-
-        PlainTextComponentSerializer plain = PlainTextComponentSerializer.plainText();
-        Iterator<Component> it = lore.iterator();
-        while (it.hasNext()) {
-            String text = plain.serialize(it.next());
-            if (text.startsWith("Level:") || text.startsWith("XP:")) {
-                it.remove();
+        List<Component> existing = meta.lore();
+        List<Component> tail = new ArrayList<>();
+        if (existing != null) {
+            PlainTextComponentSerializer plain = PlainTextComponentSerializer.plainText();
+            boolean keep = false;
+            for (Component c : existing) {
+                String text = plain.serialize(c).trim();
+                if (text.isEmpty()) {
+                    if (keep) tail.add(c);
+                    continue;
+                }
+                if (text.startsWith("✦") || text.startsWith("Rarity:") || text.startsWith("Level:") || text.startsWith("XP:")) {
+                    continue;
+                }
+                keep = true;
+                tail.add(c);
             }
         }
 
-        double ratio = req > 0 ? (double) xp / (double) req : 0.0;
-        int filled = (int) Math.round(Math.max(0.0, Math.min(1.0, ratio)) * 10.0);
-        StringBuilder bar = new StringBuilder(10);
-        for (int i = 0; i < filled; i++) bar.append('■');
-        for (int i = filled; i < 10; i++) bar.append('□');
+        MiniMessage mm = MiniMessage.miniMessage();
 
-        Component levelLine = Component.text("Level: ", NamedTextColor.GRAY)
-                .append(Component.text(level, NamedTextColor.AQUA));
-        Component xpLine = Component.text("XP: ", NamedTextColor.GRAY)
-                .append(Component.text(xp + "/" + req + " ", NamedTextColor.AQUA))
-                .append(Component.text("[", NamedTextColor.DARK_GRAY))
-                .append(Component.text(bar.toString(), NamedTextColor.AQUA))
-                .append(Component.text("]", NamedTextColor.DARK_GRAY));
+        Component rarityLine = rarityComponent(mm, rarity).decoration(TextDecoration.ITALIC, false);
+        Component levelLine = mm.deserialize("<gray>Level: </gray><aqua><bold>" + level + "</bold></aqua>")
+                .decoration(TextDecoration.ITALIC, false);
 
-        lore.add(0, levelLine);
-        lore.add(1, xpLine);
-        meta.lore(lore);
+        String bar = bar10(xp, req);
+        int pct = (int) Math.round(Math.max(0.0, Math.min(1.0, xp / (double) req)) * 100.0);
+        Component xpLine = mm.deserialize(
+                "<gray>XP: </gray><aqua>" + xp + "/" + req + "</aqua> <dark_gray>[</dark_gray><gradient:#60A5FA:#C084FC><bold>" +
+                        bar + "</bold></gradient><dark_gray>]</dark_gray> <gray>" + pct + "%</gray>")
+                .decoration(TextDecoration.ITALIC, false);
+
+        List<Component> newLore = new ArrayList<>();
+        newLore.add(rarityLine);
+        newLore.add(levelLine);
+        newLore.add(xpLine);
+        newLore.addAll(tail);
+        meta.lore(newLore);
 
         meta.addItemFlags(
                 ItemFlag.HIDE_ENCHANTS,
                 ItemFlag.HIDE_ATTRIBUTES,
                 ItemFlag.HIDE_UNBREAKABLE,
                 ItemFlag.HIDE_ADDITIONAL_TOOLTIP,
-                ItemFlag.HIDE_ARMOR_TRIM
+                ItemFlag.HIDE_ARMOR_TRIM,
+                ItemFlag.HIDE_DYE
         );
+        try {
+            meta.setEnchantmentGlintOverride(null);
+        } catch (Throwable ignored) {}
 
         item.setItemMeta(meta);
+    }
+
+    private static Component rarityComponent(MiniMessage mm, Rarity rarity) {
+        String text;
+        switch (rarity) {
+            case UNCOMMON -> text = "<bold><color:#55FF55>✦ Uncommon ✦</color></bold>";
+            case RARE -> text = "<bold><color:#55AAFF>✦ Rare ✦</color></bold>";
+            case EPIC -> text = "<bold><gradient:#8A2BE2:#C084FC>✦ Epic ✦</gradient></bold>";
+            case LEGENDARY -> text = "<bold><gradient:#FFA500:#FF66CC>✦ Legendary ✦</gradient></bold>";
+            case STARFORGED -> text = "<bold><gradient:#FF4500:#FF0000>✦ StarForged ✦</gradient></bold>";
+            case COMMON -> text = "<gray><bold>✦ Common ✦</bold>";
+            default -> text = "<gray><bold>✦ Common ✦</bold>";
+        }
+        return mm.deserialize(text);
+    }
+
+    private static String bar10(int xp, int req) {
+        int r = Math.max(req, 1);
+        double pct = Math.max(0, Math.min(1.0, xp / (double) r));
+        int filled = (int) Math.round(pct * 10.0);
+        StringBuilder sb = new StringBuilder(10);
+        for (int i = 0; i < 10; i++) sb.append(i < filled ? '■' : '□');
+        return sb.toString();
     }
 }
 


### PR DESCRIPTION
## Summary
- Render special item lore with bold rarity line, level, and XP progress bar
- Refresh lore on inventory interactions using PDC checks

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_68b6fef0fcfc83258863507b5e356a7d