### PR TITLE
Build SpecialArmorSkins for Paper 1.21.4 and simplify slot change handling

### DIFF
--- a/SpecialArmorSkins/src/main/java/com/lootforge/armorskins/SASListener.java
+++ b/SpecialArmorSkins/src/main/java/com/lootforge/armorskins/SASListener.java
@@ -5,7 +5,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -38,9 +37,7 @@ public class SASListener implements Listener {
 
     @EventHandler
     public void onSlotChange(PlayerInventorySlotChangeEvent event) {
-        if (event.getSlotType() == SlotType.ARMOR) {
-            plugin.getDisplayManager().refresh(event.getPlayer());
-        }
+        plugin.getDisplayManager().refresh(event.getPlayer());
     }
 
     @EventHandler


### PR DESCRIPTION
## Summary
- Refresh armor displays on every `PlayerInventorySlotChangeEvent` and drop slot type checks.

## Testing
- `gradle build` *(fails: Could not resolve com.comphenix.protocol:ProtocolLib:5.2.0, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb088b3d348325a0416c1d713c549c