### PR TITLE
feat: use ItemsAdder for legendary armor

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/TemplateItems.java
@@ -127,6 +127,60 @@ public final class TemplateItems {
                 out.setAmount(vanilla.getAmount());
                 it = out;
             }
+        } else if ("legendary_helm".equals(id)) {
+            var vanilla = it;
+            CustomStack cs = CustomStack.getInstance("lootforge:omega_helmet");
+            if (cs != null) {
+                ItemStack out = cs.getItemStack().clone();
+                ItemMeta dst = out.getItemMeta();
+                ItemMeta src = vanilla.getItemMeta();
+                dst = copyMeta(src, dst);
+                if (src instanceof Damageable s && dst instanceof Damageable d) {
+                    d.setDamage(s.getDamage());
+                }
+                if (src != null && src.hasCustomModelData()) {
+                    try { dst.setCustomModelData(src.getCustomModelData()); } catch (Throwable ignored) {}
+                }
+                out.setItemMeta(dst);
+                out.setAmount(vanilla.getAmount());
+                it = out;
+            }
+        } else if ("legendary_legs".equals(id)) {
+            var vanilla = it;
+            CustomStack cs = CustomStack.getInstance("lootforge:omega_leggings");
+            if (cs != null) {
+                ItemStack out = cs.getItemStack().clone();
+                ItemMeta dst = out.getItemMeta();
+                ItemMeta src = vanilla.getItemMeta();
+                dst = copyMeta(src, dst);
+                if (src instanceof Damageable s && dst instanceof Damageable d) {
+                    d.setDamage(s.getDamage());
+                }
+                if (src != null && src.hasCustomModelData()) {
+                    try { dst.setCustomModelData(src.getCustomModelData()); } catch (Throwable ignored) {}
+                }
+                out.setItemMeta(dst);
+                out.setAmount(vanilla.getAmount());
+                it = out;
+            }
+        } else if ("legendary_boots".equals(id)) {
+            var vanilla = it;
+            CustomStack cs = CustomStack.getInstance("lootforge:omega_boots");
+            if (cs != null) {
+                ItemStack out = cs.getItemStack().clone();
+                ItemMeta dst = out.getItemMeta();
+                ItemMeta src = vanilla.getItemMeta();
+                dst = copyMeta(src, dst);
+                if (src instanceof Damageable s && dst instanceof Damageable d) {
+                    d.setDamage(s.getDamage());
+                }
+                if (src != null && src.hasCustomModelData()) {
+                    try { dst.setCustomModelData(src.getCustomModelData()); } catch (Throwable ignored) {}
+                }
+                out.setItemMeta(dst);
+                out.setAmount(vanilla.getAmount());
+                it = out;
+            }
         }
 
         return new TemplateItem(id, it, cmd);


### PR DESCRIPTION
## Summary
- use ItemsAdder items for legendary helm, legs, and boots when available
- copy all metadata from vanilla items to ItemsAdder stacks

## Testing
- `gradle test --console=plain` *(fails: Could not resolve com.github.LoneDev6:api:3.6.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc192f24608325a11f319cfaa56232