### PR TITLE
Validate ItemsAdder CMD and fix omega chestplate

### DIFF
--- a/plugins/ItemsAdder/contents/lootforge/items/omega_chestplate.yml
+++ b/plugins/ItemsAdder/contents/lootforge/items/omega_chestplate.yml
@@ -1,0 +1,9 @@
+info:
+  namespace: lootforge
+items:
+  omega_chestplate:
+    display_name: "Omega Chestplate"
+    resource:
+      material: NETHERITE_CHESTPLATE
+    item:
+      custom_model_data: 2105


### PR DESCRIPTION
## Summary
- add omega chestplate item definition with CMD 2105
- warn if ItemsAdder stack CMD differs from template during load

## Testing
- `iazip` *(fails: command not found)*
- `gradle build` *(fails: Could not resolve com.github.LoneDev6:api:3.6.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bd67227f108325ab408d9fa88b7bab