### PR TITLE
Fix SpecialItems inventory desync with scheduled updates

### DIFF
--- a/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
+++ b/SpecialItems/src/main/java/com/specialitems/SpecialItemsPlugin.java
@@ -9,7 +9,7 @@ import com.specialitems.listeners.PlayerListener;
 import com.specialitems.listeners.GuiListener;
 import com.specialitems.listeners.BinListener;
 import com.specialitems.listeners.JoinFixListener;
-import com.specialitems.listeners.InventorySanityListener;
+import com.specialitems.listeners.SiInventoryListener;
 import com.specialitems.listeners.GiveInterceptListener;
 import com.specialitems.listeners.LoreUpdateListener;
 import com.specialitems.util.Configs;
@@ -32,6 +32,7 @@ public class SpecialItemsPlugin extends JavaPlugin {
 
     // Leveling service (new)
     private LevelingService leveling;
+    private boolean debug;
 
     public static SpecialItemsPlugin getInstance() {
         return instance;
@@ -39,6 +40,12 @@ public class SpecialItemsPlugin extends JavaPlugin {
 
     public LevelingService leveling() {
         return leveling;
+    }
+
+    public boolean isDebug() { return debug; }
+    public void setDebug(boolean flag) {
+        this.debug = flag;
+        com.specialitems.util.InventorySyncUtil.DEBUG_FORCE_UPDATE = flag;
     }
 
     @Override
@@ -62,7 +69,7 @@ public class SpecialItemsPlugin extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new GuiListener(), this);
             getServer().getPluginManager().registerEvents(new PlayerListener(), this);
             getServer().getPluginManager().registerEvents(new JoinFixListener(), this);
-            getServer().getPluginManager().registerEvents(new InventorySanityListener(), this);
+            getServer().getPluginManager().registerEvents(new SiInventoryListener(this), this);
             getServer().getPluginManager().registerEvents(new BinListener(this), this);
             getServer().getPluginManager().registerEvents(new GiveInterceptListener(), this);
         } catch (Throwable t) {

--- a/SpecialItems/src/main/java/com/specialitems/commands/SiCommand.java
+++ b/SpecialItems/src/main/java/com/specialitems/commands/SiCommand.java
@@ -47,6 +47,7 @@ public class SiCommand implements CommandExecutor {
         sender.sendMessage(ChatColor.YELLOW + "/si publicinspect" + ChatColor.GRAY + " — Broadcast held item");
         sender.sendMessage(ChatColor.YELLOW + "/si retag " + ChatColor.WHITE + "[id]" + ChatColor.GRAY + " — Tag held item as Special (admin)");
         sender.sendMessage(ChatColor.YELLOW + "/si dump [hand]" + ChatColor.GRAY + " — Dump CMD and PDC of held item");
+        sender.sendMessage(ChatColor.YELLOW + "/si debug on|off" + ChatColor.GRAY + " — Toggle debug mode");
     }
 
     private static boolean requirePlayer(CommandSender sender) {
@@ -209,6 +210,24 @@ public class SiCommand implements CommandExecutor {
                 String joined = kset.isEmpty() ? "(none)" : kset.stream().map(NamespacedKey::toString)
                         .collect(Collectors.joining(", "));
                 p.sendMessage(ChatColor.GOLD + "PDC Keys: " + ChatColor.YELLOW + joined);
+                return true;
+            }
+            case "debug" -> {
+                if (!requireAdmin(sender)) return true;
+                if (args.length < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /si debug on|off");
+                    return true;
+                }
+                boolean flag;
+                if (args[1].equalsIgnoreCase("on")) flag = true;
+                else if (args[1].equalsIgnoreCase("off")) flag = false;
+                else {
+                    sender.sendMessage(ChatColor.RED + "Usage: /si debug on|off");
+                    return true;
+                }
+                SpecialItemsPlugin pl = SpecialItemsPlugin.getInstance();
+                pl.setDebug(flag);
+                sender.sendMessage(ChatColor.GREEN + "Debug mode " + (flag ? "enabled" : "disabled"));
                 return true;
             }
             case "list" -> {

--- a/SpecialItems/src/main/java/com/specialitems/listeners/SiInventoryListener.java
+++ b/SpecialItems/src/main/java/com/specialitems/listeners/SiInventoryListener.java
@@ -1,0 +1,117 @@
+package com.specialitems.listeners;
+
+import com.specialitems.SpecialItemsPlugin;
+import com.specialitems.util.InventorySyncUtil;
+import com.specialitems.util.ItemUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+/** Handles inventory interactions for SpecialItems to avoid client desync. */
+public final class SiInventoryListener implements Listener {
+    private static final Logger LOG = Logger.getLogger("SpecialItems/InventorySync");
+    private final SpecialItemsPlugin plugin;
+
+    public SiInventoryListener(SpecialItemsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    private void log(Player p, int slot, String action, ItemStack cursor) {
+        if (!plugin.isDebug()) return;
+        String cur = cursor == null ? "null" : cursor.getType().name();
+        LOG.info(p.getName() + " slot=" + slot + " action=" + action +
+                " cursor=" + cur + " usedNextTick=true updateInvCalled=" + InventorySyncUtil.DEBUG_FORCE_UPDATE);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onClick(InventoryClickEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        ItemStack current = e.getCurrentItem();
+        if (current == null || current.getType().isAir()) return;
+        ItemStack clone = current.clone();
+        if (!ItemUtil.normalizeCustomModelData(clone)) return; // nothing to do
+
+        int slot = e.getSlot();
+        InventoryAction act = e.getAction();
+        ItemStack cursor = e.getCursor();
+        e.setCancelled(true);
+
+        switch (act) {
+            case MOVE_TO_OTHER_INVENTORY -> { // shift-click
+                Inventory clicked = e.getClickedInventory();
+                if (clicked == p.getInventory()) {
+                    Bukkit.getScheduler().runTask(plugin, () -> {
+                        Inventory top = e.getView().getTopInventory();
+                        Map<Integer, ItemStack> leftover = top.addItem(clone);
+                        ItemStack remain = leftover.isEmpty() ? null : leftover.values().iterator().next();
+                        p.getInventory().setItem(slot, remain);
+                        InventorySyncUtil.updateIfNeeded(p);
+                    });
+                } else {
+                    Bukkit.getScheduler().runTask(plugin, () -> {
+                        clicked.setItem(slot, null);
+                        var leftover = p.getInventory().addItem(clone);
+                        leftover.values().forEach(it -> p.getWorld().dropItemNaturally(p.getLocation(), it));
+                        InventorySyncUtil.updateIfNeeded(p);
+                    });
+                }
+                InventorySyncUtil.clearCursorNextTick(plugin, p);
+                log(p, slot, act.name(), cursor);
+            }
+            case SWAP_WITH_CURSOR -> {
+                ItemStack cursorClone = cursor == null ? null : cursor.clone();
+                if (cursorClone != null) ItemUtil.normalizeCustomModelData(cursorClone);
+                InventorySyncUtil.setSlotNextTick(plugin, p, slot, cursorClone);
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    p.setItemOnCursor(clone);
+                    InventorySyncUtil.updateIfNeeded(p);
+                });
+                log(p, slot, act.name(), cursor);
+            }
+            case HOTBAR_SWAP, HOTBAR_MOVE_AND_READD -> {
+                int hotbar = e.getHotbarButton();
+                ItemStack hot = p.getInventory().getItem(hotbar);
+                ItemStack hotClone = hot == null ? null : hot.clone();
+                if (hotClone != null) ItemUtil.normalizeCustomModelData(hotClone);
+                InventorySyncUtil.setSlotNextTick(plugin, p, slot, hotClone);
+                InventorySyncUtil.setSlotNextTick(plugin, p, hotbar, clone);
+                InventorySyncUtil.clearCursorNextTick(plugin, p);
+                log(p, slot, act.name(), cursor);
+            }
+            default -> {
+                InventorySyncUtil.setSlotNextTick(plugin, p, slot, clone);
+                InventorySyncUtil.clearCursorNextTick(plugin, p);
+                log(p, slot, act.name(), cursor);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onDrag(InventoryDragEvent e) {
+        if (!(e.getWhoClicked() instanceof Player p)) return;
+        boolean changed = false;
+        for (Map.Entry<Integer, ItemStack> ent : e.getNewItems().entrySet()) {
+            ItemStack clone = ent.getValue().clone();
+            if (ItemUtil.normalizeCustomModelData(clone)) {
+                changed = true;
+                int slot = ent.getKey();
+                InventorySyncUtil.setSlotNextTick(plugin, p, slot, clone);
+                log(p, slot, "DRAG", e.getCursor());
+            }
+        }
+        if (changed) {
+            e.setCancelled(true);
+            InventorySyncUtil.clearCursorNextTick(plugin, p);
+        }
+    }
+}

--- a/SpecialItems/src/main/java/com/specialitems/util/InventorySyncUtil.java
+++ b/SpecialItems/src/main/java/com/specialitems/util/InventorySyncUtil.java
@@ -1,0 +1,49 @@
+package com.specialitems.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+/** Utility for safely synchronizing inventory changes to the client. */
+public final class InventorySyncUtil {
+
+    private InventorySyncUtil() {}
+
+    /** When true forces Player#updateInventory after each change. */
+    public static boolean DEBUG_FORCE_UPDATE = false;
+
+    /** Schedule setting a slot in the player's inventory on the next tick. */
+    public static void setSlotNextTick(Plugin plugin, Player player, int slot, @Nullable ItemStack stack) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            player.getInventory().setItem(slot, stack);
+            updateIfNeeded(player);
+        });
+    }
+
+    /** Clears the player's cursor on the next tick. */
+    public static void clearCursorNextTick(Plugin plugin, Player player) {
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            player.setItemOnCursor(null);
+            updateIfNeeded(player);
+        });
+    }
+
+    /** Give the item to the player or drop it at their feet if inventory is full. */
+    public static void giveOrDrop(Plugin plugin, Player player, ItemStack stack) {
+        if (stack == null || stack.getType().isAir()) return;
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            var leftover = player.getInventory().addItem(stack);
+            leftover.values().forEach(it -> player.getWorld().dropItemNaturally(player.getLocation(), it));
+            updateIfNeeded(player);
+        });
+    }
+
+    /** Calls {@link Player#updateInventory()} if debugging is enabled. */
+    public static void updateIfNeeded(Player player) {
+        if (DEBUG_FORCE_UPDATE) {
+            player.updateInventory();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `InventorySyncUtil` to safely update slots, cursors and drops next tick
- replace `InventorySanityListener` with `SiInventoryListener` to clone & resync items and log actions
- expose `/si debug on|off` toggle and hook into new DEBUG_FORCE_UPDATE flag

## Testing
- `gradle build` *(fails: Could not resolve com.github.LoneDev6:api:3.6.1 - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0264e1c388325a5af23a7409eca16